### PR TITLE
[ARCTIC-1277] Support writing partial and out-of-order field data into mixed format tables

### DIFF
--- a/core/src/test/java/com/netease/arctic/TableTestHelpers.java
+++ b/core/src/test/java/com/netease/arctic/TableTestHelpers.java
@@ -37,6 +37,10 @@ public class TableTestHelpers {
   public static final String TEST_CATALOG_NAME = "test_catalog";
   public static final String TEST_DB_NAME = "test_db";
   public static final String TEST_TABLE_NAME = "test_table";
+  public static final String COLUMN_NAME_ID = "id";
+  public static final String COLUMN_NAME_NAME = "name";
+  public static final String COLUMN_NAME_TS = "ts";
+  public static final String COLUMN_NAME_OP_TIME = "op_time";
 
   public static final TableIdentifier TEST_TABLE_ID =
       TableIdentifier.of(TEST_CATALOG_NAME, TEST_DB_NAME, TEST_TABLE_NAME);
@@ -45,22 +49,22 @@ public class TableTestHelpers {
       org.apache.iceberg.catalog.TableIdentifier.of(TEST_DB_NAME, TEST_TABLE_NAME);
 
   public static final Schema TABLE_SCHEMA = new Schema(
-      Types.NestedField.required(1, "id", Types.IntegerType.get()),
-      Types.NestedField.required(2, "name", Types.StringType.get()),
-      Types.NestedField.required(3, "ts", Types.LongType.get()),
-      Types.NestedField.required(4, "op_time", Types.TimestampType.withoutZone())
+      Types.NestedField.required(1, COLUMN_NAME_ID, Types.IntegerType.get()),
+      Types.NestedField.required(2, COLUMN_NAME_NAME, Types.StringType.get()),
+      Types.NestedField.required(3, COLUMN_NAME_TS, Types.LongType.get()),
+      Types.NestedField.required(4, COLUMN_NAME_OP_TIME, Types.TimestampType.withoutZone())
   );
 
   public static final PartitionSpec SPEC = PartitionSpec.builderFor(TABLE_SCHEMA)
-      .day("op_time").build();
+      .day(COLUMN_NAME_OP_TIME).build();
 
   public static final PartitionSpec IDENTIFY_SPEC = PartitionSpec.builderFor(TABLE_SCHEMA)
-      .identity("op_time").build();
+      .identity(COLUMN_NAME_OP_TIME).build();
 
   public static final Record RECORD = GenericRecord.create(TABLE_SCHEMA);
 
   public static final PrimaryKeySpec PRIMARY_KEY_SPEC = PrimaryKeySpec.builderFor(TABLE_SCHEMA)
-      .addColumn("id").build();
+      .addColumn(COLUMN_NAME_ID).build();
 
   private static final Map<String, DataFile> DATA_FILE_MAP = Maps.newHashMap();
 
@@ -104,6 +108,4 @@ public class TableTestHelpers {
     }
     return fileBuilder.build();
   }
-
-
 }

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/FlinkTableTestBase.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/FlinkTableTestBase.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.flink;
+
+import com.netease.arctic.flink.table.ArcticTableLoader;
+import com.netease.arctic.flink.write.ArcticRowDataTaskWriterFactory;
+import com.netease.arctic.table.ArcticTable;
+import com.netease.arctic.table.KeyedTable;
+import com.netease.arctic.table.TableIdentifier;
+import com.netease.arctic.table.UnkeyedTable;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.iceberg.AppendFiles;
+import org.apache.iceberg.io.TaskWriter;
+import org.apache.iceberg.io.WriteResult;
+
+import java.util.Arrays;
+
+/**
+ * This class contains flink table rowType schema and others,
+ * and will replace {@link FlinkTestBase} base class in the future.
+ */
+public interface FlinkTableTestBase {
+
+  default TaskWriter<RowData> createKeyedTaskWriter(
+      KeyedTable keyedTable,
+      RowType rowType) {
+    return createKeyedTaskWriter(keyedTable, rowType, false, 3);
+  }
+
+  default TaskWriter<RowData> createKeyedTaskWriter(
+      KeyedTable keyedTable,
+      RowType rowType,
+      boolean overwrite,
+      long mask) {
+    return createTaskWriter(keyedTable, rowType, overwrite, mask);
+  }
+
+  default TaskWriter<RowData> createUnkeyedTaskWriter(
+      UnkeyedTable unkeyedTable,
+      RowType rowType) {
+    return createTaskWriter(unkeyedTable, rowType, false, 3);
+  }
+
+  default TaskWriter<RowData> createTaskWriter(
+      ArcticTable arcticTable,
+      RowType rowType,
+      boolean overwrite,
+      long mask) {
+    ArcticRowDataTaskWriterFactory taskWriterFactory =
+        new ArcticRowDataTaskWriterFactory(arcticTable, rowType, overwrite);
+    taskWriterFactory.setMask(mask);
+    taskWriterFactory.initialize(0, 0);
+    return taskWriterFactory.create();
+  }
+
+  default void commit(ArcticTable arcticTable, WriteResult result, boolean base) {
+    if (arcticTable.isKeyedTable()) {
+      KeyedTable keyedTable = arcticTable.asKeyedTable();
+      if (base) {
+        AppendFiles baseAppend = keyedTable.baseTable().newAppend();
+        Arrays.stream(result.dataFiles()).forEach(baseAppend::appendFile);
+        baseAppend.commit();
+      } else {
+        AppendFiles changeAppend = keyedTable.changeTable().newAppend();
+        Arrays.stream(result.dataFiles()).forEach(changeAppend::appendFile);
+        changeAppend.commit();
+      }
+    } else {
+      if (!base) {
+        throw new IllegalArgumentException(
+            String.format("arctic table %s is a unkeyed table, can't commit to change table", arcticTable.name()));
+      }
+      UnkeyedTable unkeyedTable = arcticTable.asUnkeyedTable();
+      AppendFiles baseAppend = unkeyedTable.newAppend();
+      Arrays.stream(result.dataFiles()).forEach(baseAppend::appendFile);
+      baseAppend.commit();
+    }
+  }
+
+  default ArcticTableLoader getTableLoader(String catalogName, String metastoreUrl, ArcticTable arcticTable) {
+    TableIdentifier identifier = TableIdentifier.of(
+        catalogName,
+        arcticTable.id().getDatabase(),
+        arcticTable.id().getTableName());
+    InternalCatalogBuilder internalCatalogBuilder =
+        InternalCatalogBuilder.builder().metastoreUrl(metastoreUrl);
+    return ArcticTableLoader.of(identifier, internalCatalogBuilder, arcticTable.properties());
+  }
+}

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/write/FlinkArcticTaskWriterBuilderTest.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/write/FlinkArcticTaskWriterBuilderTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.flink.write;
+
+import com.netease.arctic.ams.api.properties.TableFormat;
+import com.netease.arctic.catalog.TableTestBase;
+import com.netease.arctic.flink.util.DataUtil;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.data.RowData;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.time.LocalDateTime;
+
+import static com.netease.arctic.TableTestHelpers.COLUMN_NAME_ID;
+import static com.netease.arctic.TableTestHelpers.COLUMN_NAME_NAME;
+import static com.netease.arctic.TableTestHelpers.COLUMN_NAME_OP_TIME;
+import static com.netease.arctic.TableTestHelpers.COLUMN_NAME_TS;
+
+/**
+ * This is a mix_iceberg writer test.
+ */
+@RunWith(value = Parameterized.class)
+public class FlinkArcticTaskWriterBuilderTest extends TableTestBase implements FlinkTaskWriterBaseTest {
+
+  public FlinkArcticTaskWriterBuilderTest(
+      boolean keyedTable,
+      boolean partitionedTable) {
+    super(TableFormat.MIXED_ICEBERG, keyedTable, partitionedTable);
+  }
+
+  @Parameterized.Parameters(name = "keyedTable = {0}, partitionedTable = {1}")
+  public static Object[][] parameters() {
+    return new Object[][]{
+        {true, true},
+        {true, false},
+        {false, true},
+        {false, false}};
+  }
+
+  @Test
+  public void testWriteToArcticWithPartialSchema() {
+    TableSchema flinkPartialSchema = TableSchema.builder()
+        .field(COLUMN_NAME_ID, DataTypes.INT())
+        .field(COLUMN_NAME_NAME, DataTypes.STRING())
+        .field(COLUMN_NAME_OP_TIME, DataTypes.TIMESTAMP())
+        .build();
+    RowData expected = DataUtil.toRowData(1000004, "a", LocalDateTime.parse("2022-06-18T10:10:11.0"));
+    testWriteAndReadArcticTable(getArcticTable(), flinkPartialSchema, expected);
+  }
+
+  /**
+   * The order of flink table schema fields is different from that of arctic table schema fields.
+   */
+  @Test
+  public void testWriteToArcticWithOutOfOrderFieldsAndPK() {
+    TableSchema flinkTableSchemaOutOfOrderFields = TableSchema.builder()
+        .field(COLUMN_NAME_TS, DataTypes.BIGINT())
+        .field(COLUMN_NAME_ID, DataTypes.INT())
+        .field(COLUMN_NAME_NAME, DataTypes.STRING())
+        .field(COLUMN_NAME_OP_TIME, DataTypes.TIMESTAMP())
+        .build();
+    RowData expected = DataUtil.toRowData(System.currentTimeMillis(), 1000004, "a", LocalDateTime.parse("2022-06-18T10:10:11.0"));
+    testWriteAndReadArcticTable(getArcticTable(), flinkTableSchemaOutOfOrderFields, expected);
+  }
+
+  @Override
+  public String getMetastoreUrl() {
+    return getCatalogUrl();
+  }
+
+  @Override
+  public String getCatalogName() {
+    return getCatalog().name();
+  }
+}

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/write/FlinkHiveTaskWriterBuilderTest.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/write/FlinkHiveTaskWriterBuilderTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.flink.write;
+
+import com.google.common.collect.Maps;
+import com.netease.arctic.flink.util.DataUtil;
+import com.netease.arctic.hive.catalog.HiveTableTestBase;
+import com.netease.arctic.table.PrimaryKeySpec;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.data.RowData;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.types.Types;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.time.LocalDateTime;
+
+/**
+ * This is a mix_hive table writer test.
+ */
+@RunWith(value = Parameterized.class)
+public class FlinkHiveTaskWriterBuilderTest extends HiveTableTestBase implements FlinkTaskWriterBaseTest {
+
+  public static final Schema HIVE_TABLE_SCHEMA = new Schema(
+      Types.NestedField.required(1, COLUMN_NAME_ID, Types.IntegerType.get()),
+      Types.NestedField.required(2, COLUMN_NAME_OP_TIME, Types.TimestampType.withoutZone()),
+      Types.NestedField.optional(3, COLUMN_NAME_OP_TIME_WITH_ZONE, Types.TimestampType.withZone()),
+      Types.NestedField.optional(4, COLUMN_NAME_D, Types.DecimalType.of(10, 0)),
+      Types.NestedField.required(5, COLUMN_NAME_NAME, Types.StringType.get())
+  );
+
+  public static final PrimaryKeySpec PRIMARY_KEY_SPEC = PrimaryKeySpec.builderFor(HIVE_TABLE_SCHEMA)
+      .addColumn(COLUMN_NAME_ID).build();
+
+  public FlinkHiveTaskWriterBuilderTest(
+      boolean keyedTable,
+      boolean partitionedTable) {
+    super(
+        HIVE_TABLE_SCHEMA,
+        keyedTable ?
+            PRIMARY_KEY_SPEC :
+            PrimaryKeySpec.noPrimaryKey(),
+        partitionedTable ?
+            PartitionSpec.builderFor(HIVE_TABLE_SCHEMA).identity(COLUMN_NAME_NAME).build() :
+            PartitionSpec.unpartitioned(),
+        Maps.newHashMap());
+  }
+
+  @Parameterized.Parameters(name = "keyedTable = {0}, partitionedTable = {1}")
+  public static Object[][] parameters() {
+    return new Object[][]{
+        {true, true},
+        {true, false},
+        {false, true},
+        {false, false}};
+  }
+
+  @Test
+  public void testPartialWriteToArctic() {
+    TableSchema flinkPartialSchema = TableSchema.builder()
+        .field(COLUMN_NAME_ID, DataTypes.INT())
+        .field(COLUMN_NAME_OP_TIME, DataTypes.TIMESTAMP())
+        .field(COLUMN_NAME_NAME, DataTypes.STRING())
+        .build();
+    RowData expected = DataUtil.toRowData(1000004, LocalDateTime.parse("2022-06-18T10:10:11.0"), "a");
+    testWriteAndReadArcticTable(getArcticTable(), flinkPartialSchema, expected);
+  }
+
+  @Test
+  public void testWriteOutOfOrderFieldsFromArctic() {
+    TableSchema flinkTableSchemaOutOfOrderFields = TableSchema.builder()
+        .field(COLUMN_NAME_D, DataTypes.STRING())
+        .field(COLUMN_NAME_ID, DataTypes.INT())
+        .field(COLUMN_NAME_OP_TIME, DataTypes.TIMESTAMP())
+        .field(COLUMN_NAME_NAME, DataTypes.STRING())
+        .build();
+    RowData expected = DataUtil.toRowData("dd", 1000004, LocalDateTime.parse("2022-06-18T10:10:11.0"), "a");
+    testWriteAndReadArcticTable(getArcticTable(), flinkTableSchemaOutOfOrderFields, expected);
+  }
+
+  @Override
+  public String getMetastoreUrl() {
+    return getCatalogUrl();
+  }
+
+  @Override
+  public String getCatalogName() {
+    return getCatalog().name();
+  }
+}

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/write/FlinkTaskWriterBaseTest.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/write/FlinkTaskWriterBaseTest.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.flink.write;
+
+import com.netease.arctic.flink.FlinkTableTestBase;
+import com.netease.arctic.flink.read.FlinkSplitPlanner;
+import com.netease.arctic.flink.read.hybrid.reader.RowDataReaderFunction;
+import com.netease.arctic.flink.read.hybrid.split.ArcticSplit;
+import com.netease.arctic.flink.read.source.DataIterator;
+import com.netease.arctic.io.ArcticFileIO;
+import com.netease.arctic.table.ArcticTable;
+import com.netease.arctic.table.KeyedTable;
+import com.netease.arctic.table.UnkeyedTable;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.flink.FlinkSchemaUtil;
+import org.apache.iceberg.flink.TableLoader;
+import org.apache.iceberg.flink.TestHelpers;
+import org.apache.iceberg.flink.source.FlinkInputFormat;
+import org.apache.iceberg.flink.source.FlinkSource;
+import org.apache.iceberg.io.TaskWriter;
+import org.apache.iceberg.io.WriteResult;
+import org.apache.iceberg.types.TypeUtil;
+import org.junit.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.netease.arctic.TableTestHelpers.PRIMARY_KEY_SPEC;
+
+public interface FlinkTaskWriterBaseTest extends FlinkTableTestBase {
+  Logger LOG = LoggerFactory.getLogger(FlinkTaskWriterBaseTest.class);
+
+  default void testWriteAndReadArcticTable(
+      ArcticTable arcticTable,
+      TableSchema flinkTableSchema,
+      RowData expected) {
+
+    // This is a partial-write schema from Flink engine view.
+    RowType rowType = (RowType) flinkTableSchema.toRowDataType().getLogicalType();
+
+    try (TaskWriter<RowData> taskWriter =
+             arcticTable.isKeyedTable() ?
+                 createKeyedTaskWriter((KeyedTable) arcticTable, rowType) :
+                 createUnkeyedTaskWriter((UnkeyedTable) arcticTable, rowType)) {
+      Assert.assertNotNull(taskWriter);
+
+      writeAndCommit(expected, taskWriter, arcticTable);
+
+      arcticTable.refresh();
+
+      // This is a partial-read schema from Flink engine view, should reassign schema id to selected-schema
+      Schema selectedSchema = TypeUtil.reassignIds(FlinkSchemaUtil.convert(flinkTableSchema), arcticTable.schema());
+
+      assertRecords(selectedSchema, arcticTable, expected, flinkTableSchema);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  default void assertRecords(
+      Schema selectedSchema,
+      ArcticTable arcticTable,
+      RowData expected,
+      TableSchema flinkTableSchema) throws IOException {
+    List<RowData> records;
+    if (arcticTable.isKeyedTable()) {
+      records =
+          recordsOfKeyedTable(
+              arcticTable.asKeyedTable(),
+              selectedSchema,
+              arcticTable.io());
+    } else {
+      records =
+          recordsOfUnkeyedTable(
+              getTableLoader(getCatalogName(), getMetastoreUrl(), arcticTable),
+              selectedSchema,
+              flinkTableSchema
+          );
+    }
+    Assert.assertEquals(1, records.size());
+    Assert.assertEquals(expected, records.get(0));
+  }
+
+  /**
+   * For asserting unkeyed table records.
+   */
+  String getMetastoreUrl();
+
+  /**
+   * For asserting unkeyed table records.
+   */
+  String getCatalogName();
+
+  default void writeAndCommit(RowData expected, TaskWriter<RowData> taskWriter, ArcticTable arcticTable) throws IOException {
+    taskWriter.write(expected);
+    WriteResult writerResult = taskWriter.complete();
+    boolean writeToBase = arcticTable.isUnkeyedTable();
+    commit(arcticTable, writerResult, writeToBase);
+    Assert.assertEquals(1, writerResult.dataFiles().length);
+  }
+
+  default List<RowData> recordsOfUnkeyedTable(
+      TableLoader tableLoader,
+      Schema projectedSchema,
+      TableSchema flinkTableSchema) throws IOException {
+    FlinkInputFormat inputFormat = FlinkSource.forRowData()
+        .tableLoader(tableLoader)
+        .project(flinkTableSchema)
+        .buildFormat();
+    return runFormat(inputFormat, FlinkSchemaUtil.convert(projectedSchema));
+  }
+
+  default List<RowData> recordsOfKeyedTable(
+      KeyedTable table,
+      Schema projectedSchema,
+      ArcticFileIO io) {
+    List<ArcticSplit> arcticSplits = FlinkSplitPlanner.planFullTable(table, new AtomicInteger(0));
+
+    RowDataReaderFunction rowDataReaderFunction =
+        new RowDataReaderFunction(
+            new Configuration(),
+            projectedSchema,
+            projectedSchema,
+            PRIMARY_KEY_SPEC,
+            null,
+            true,
+            io
+        );
+
+    List<RowData> actual = new ArrayList<>();
+    arcticSplits.forEach(split -> {
+      LOG.info("ArcticSplit {}.", split);
+      DataIterator<RowData> dataIterator = rowDataReaderFunction.createDataIterator(split);
+      while (dataIterator.hasNext()) {
+        RowData rowData = dataIterator.next();
+        LOG.info("{}", rowData);
+        actual.add(rowData);
+      }
+    });
+
+    return actual;
+  }
+
+  default List<RowData> runFormat(FlinkInputFormat inputFormat, RowType readRowType) throws IOException {
+    return TestHelpers.readRowData(inputFormat, readRowType);
+  }
+}

--- a/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/write/FlinkTaskWriterBaseTest.java
+++ b/flink/v1.12/flink/src/test/java/com/netease/arctic/flink/write/FlinkTaskWriterBaseTest.java
@@ -75,13 +75,14 @@ public interface FlinkTaskWriterBaseTest extends FlinkTableTestBase {
       // This is a partial-read schema from Flink engine view, should reassign schema id to selected-schema
       Schema selectedSchema = TypeUtil.reassignIds(FlinkSchemaUtil.convert(flinkTableSchema), arcticTable.schema());
 
-      assertRecords(selectedSchema, arcticTable, expected, flinkTableSchema);
+      assertRecords(arcticTable.schema(), selectedSchema, arcticTable, expected, flinkTableSchema);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
   }
 
   default void assertRecords(
+      Schema tableSchema,
       Schema selectedSchema,
       ArcticTable arcticTable,
       RowData expected,
@@ -91,6 +92,7 @@ public interface FlinkTaskWriterBaseTest extends FlinkTableTestBase {
       records =
           recordsOfKeyedTable(
               arcticTable.asKeyedTable(),
+              tableSchema,
               selectedSchema,
               arcticTable.io());
     } else {
@@ -136,6 +138,7 @@ public interface FlinkTaskWriterBaseTest extends FlinkTableTestBase {
 
   default List<RowData> recordsOfKeyedTable(
       KeyedTable table,
+      Schema tableSchema,
       Schema projectedSchema,
       ArcticFileIO io) {
     List<ArcticSplit> arcticSplits = FlinkSplitPlanner.planFullTable(table, new AtomicInteger(0));
@@ -143,7 +146,7 @@ public interface FlinkTaskWriterBaseTest extends FlinkTableTestBase {
     RowDataReaderFunction rowDataReaderFunction =
         new RowDataReaderFunction(
             new Configuration(),
-            projectedSchema,
+            tableSchema,
             projectedSchema,
             PRIMARY_KEY_SPEC,
             null,

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/FlinkTaskWriterBuilder.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/write/FlinkTaskWriterBuilder.java
@@ -144,9 +144,9 @@ public class FlinkTaskWriterBuilder implements TaskWriterBuilder<RowData> {
         new CommonOutputFileFactory(baseLocation, table.spec(), fileFormat, table.io(),
             encryptionManager, partitionId, taskId, transactionId);
     FileAppenderFactory<RowData> appenderFactory = TableTypeUtil.isHive(table) ?
-        new AdaptHiveFlinkAppenderFactory(schema, flinkSchema, table.properties(), table.spec()) :
+        new AdaptHiveFlinkAppenderFactory(selectSchema, flinkSchema, table.properties(), table.spec()) :
         new FlinkAppenderFactory(
-            schema, flinkSchema, table.properties(), table.spec());
+            selectSchema, flinkSchema, table.properties(), table.spec());
     return new FlinkBaseTaskWriter(
         fileFormat,
         appenderFactory,
@@ -170,17 +170,17 @@ public class FlinkTaskWriterBuilder implements TaskWriterBuilder<RowData> {
     KeyedTable keyedTable = table.asKeyedTable();
     Schema selectSchema = TypeUtil.reassignIds(
         FlinkSchemaUtil.convert(FlinkSchemaUtil.toSchema(flinkSchema)), keyedTable.baseTable().schema());
-    Schema changeSchemaWithMeta = SchemaUtil.changeWriteSchema(keyedTable.baseTable().schema());
-    RowType flinkSchemaWithMeta = FlinkSchemaUtil.convert(changeSchemaWithMeta);
+    Schema selectedSchemaWithMeta = SchemaUtil.changeWriteSchema(selectSchema);
+    RowType flinkSchemaWithMeta = FlinkSchemaUtil.convert(selectedSchemaWithMeta);
 
     OutputFileFactory outputFileFactory = new CommonOutputFileFactory(keyedTable.changeLocation(),
         keyedTable.spec(), fileFormat, keyedTable.io(), keyedTable.baseTable().encryption(), partitionId,
         taskId, transactionId);
     FileAppenderFactory<RowData> appenderFactory = TableTypeUtil.isHive(table) ?
-        new AdaptHiveFlinkAppenderFactory(changeSchemaWithMeta, flinkSchemaWithMeta,
+        new AdaptHiveFlinkAppenderFactory(selectedSchemaWithMeta, flinkSchemaWithMeta,
             keyedTable.properties(), keyedTable.spec()) :
         new FlinkAppenderFactory(
-            changeSchemaWithMeta, flinkSchemaWithMeta, keyedTable.properties(), keyedTable.spec());
+            selectedSchemaWithMeta, flinkSchemaWithMeta, keyedTable.properties(), keyedTable.spec());
     boolean upsert = table.isKeyedTable() && PropertyUtil.propertyAsBoolean(table.properties(),
         TableProperties.UPSERT_ENABLED, TableProperties.UPSERT_ENABLED_DEFAULT);
     return new FlinkChangeTaskWriter(

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/FlinkTableTestBase.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/FlinkTableTestBase.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.flink;
+
+import com.netease.arctic.flink.table.ArcticTableLoader;
+import com.netease.arctic.flink.write.ArcticRowDataTaskWriterFactory;
+import com.netease.arctic.table.ArcticTable;
+import com.netease.arctic.table.KeyedTable;
+import com.netease.arctic.table.TableIdentifier;
+import com.netease.arctic.table.UnkeyedTable;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.iceberg.AppendFiles;
+import org.apache.iceberg.io.TaskWriter;
+import org.apache.iceberg.io.WriteResult;
+
+import java.util.Arrays;
+
+/**
+ * This class contains flink table rowType schema and others,
+ * and will replace {@link FlinkTestBase} base class in the future.
+ */
+public interface FlinkTableTestBase {
+
+  default TaskWriter<RowData> createKeyedTaskWriter(
+      KeyedTable keyedTable,
+      RowType rowType) {
+    return createKeyedTaskWriter(keyedTable, rowType, false, 3);
+  }
+
+  default TaskWriter<RowData> createKeyedTaskWriter(
+      KeyedTable keyedTable,
+      RowType rowType,
+      boolean overwrite,
+      long mask) {
+    return createTaskWriter(keyedTable, rowType, overwrite, mask);
+  }
+
+  default TaskWriter<RowData> createUnkeyedTaskWriter(
+      UnkeyedTable unkeyedTable,
+      RowType rowType) {
+    return createTaskWriter(unkeyedTable, rowType, false, 3);
+  }
+
+  default TaskWriter<RowData> createTaskWriter(
+      ArcticTable arcticTable,
+      RowType rowType,
+      boolean overwrite,
+      long mask) {
+    ArcticRowDataTaskWriterFactory taskWriterFactory =
+        new ArcticRowDataTaskWriterFactory(arcticTable, rowType, overwrite);
+    taskWriterFactory.setMask(mask);
+    taskWriterFactory.initialize(0, 0);
+    return taskWriterFactory.create();
+  }
+
+  default void commit(ArcticTable arcticTable, WriteResult result, boolean base) {
+    if (arcticTable.isKeyedTable()) {
+      KeyedTable keyedTable = arcticTable.asKeyedTable();
+      if (base) {
+        AppendFiles baseAppend = keyedTable.baseTable().newAppend();
+        Arrays.stream(result.dataFiles()).forEach(baseAppend::appendFile);
+        baseAppend.commit();
+      } else {
+        AppendFiles changeAppend = keyedTable.changeTable().newAppend();
+        Arrays.stream(result.dataFiles()).forEach(changeAppend::appendFile);
+        changeAppend.commit();
+      }
+    } else {
+      if (!base) {
+        throw new IllegalArgumentException(
+            String.format("arctic table %s is a unkeyed table, can't commit to change table", arcticTable.name()));
+      }
+      UnkeyedTable unkeyedTable = arcticTable.asUnkeyedTable();
+      AppendFiles baseAppend = unkeyedTable.newAppend();
+      Arrays.stream(result.dataFiles()).forEach(baseAppend::appendFile);
+      baseAppend.commit();
+    }
+  }
+
+  default ArcticTableLoader getTableLoader(String catalogName, String metastoreUrl, ArcticTable arcticTable) {
+    TableIdentifier identifier = TableIdentifier.of(
+        catalogName,
+        arcticTable.id().getDatabase(),
+        arcticTable.id().getTableName());
+    InternalCatalogBuilder internalCatalogBuilder =
+        InternalCatalogBuilder.builder().metastoreUrl(metastoreUrl);
+    return ArcticTableLoader.of(identifier, internalCatalogBuilder, arcticTable.properties());
+  }
+}

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/write/FlinkArcticTaskWriterBuilderTest.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/write/FlinkArcticTaskWriterBuilderTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.flink.write;
+
+import com.netease.arctic.ams.api.properties.TableFormat;
+import com.netease.arctic.catalog.TableTestBase;
+import com.netease.arctic.flink.util.DataUtil;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.data.RowData;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.time.LocalDateTime;
+
+import static com.netease.arctic.TableTestHelpers.COLUMN_NAME_ID;
+import static com.netease.arctic.TableTestHelpers.COLUMN_NAME_NAME;
+import static com.netease.arctic.TableTestHelpers.COLUMN_NAME_OP_TIME;
+import static com.netease.arctic.TableTestHelpers.COLUMN_NAME_TS;
+
+/**
+ * This is a mix_iceberg writer test.
+ */
+@RunWith(value = Parameterized.class)
+public class FlinkArcticTaskWriterBuilderTest extends TableTestBase implements FlinkTaskWriterBaseTest {
+
+  public FlinkArcticTaskWriterBuilderTest(
+      boolean keyedTable,
+      boolean partitionedTable) {
+    super(TableFormat.MIXED_ICEBERG, keyedTable, partitionedTable);
+  }
+
+  @Parameterized.Parameters(name = "keyedTable = {0}, partitionedTable = {1}")
+  public static Object[][] parameters() {
+    return new Object[][]{
+        {true, true},
+        {true, false},
+        {false, true},
+        {false, false}};
+  }
+
+  @Test
+  public void testWriteToArcticWithPartialSchema() {
+    TableSchema flinkPartialSchema = TableSchema.builder()
+        .field(COLUMN_NAME_ID, DataTypes.INT())
+        .field(COLUMN_NAME_NAME, DataTypes.STRING())
+        .field(COLUMN_NAME_OP_TIME, DataTypes.TIMESTAMP())
+        .build();
+    RowData expected = DataUtil.toRowData(1000004, "a", LocalDateTime.parse("2022-06-18T10:10:11.0"));
+    testWriteAndReadArcticTable(getArcticTable(), flinkPartialSchema, expected);
+  }
+
+  /**
+   * The order of flink table schema fields is different from that of arctic table schema fields.
+   */
+  @Test
+  public void testWriteToArcticWithOutOfOrderFieldsAndPK() {
+    TableSchema flinkTableSchemaOutOfOrderFields = TableSchema.builder()
+        .field(COLUMN_NAME_TS, DataTypes.BIGINT())
+        .field(COLUMN_NAME_ID, DataTypes.INT())
+        .field(COLUMN_NAME_NAME, DataTypes.STRING())
+        .field(COLUMN_NAME_OP_TIME, DataTypes.TIMESTAMP())
+        .build();
+    RowData expected = DataUtil.toRowData(System.currentTimeMillis(), 1000004, "a", LocalDateTime.parse("2022-06-18T10:10:11.0"));
+    testWriteAndReadArcticTable(getArcticTable(), flinkTableSchemaOutOfOrderFields, expected);
+  }
+
+  @Override
+  public String getMetastoreUrl() {
+    return getCatalogUrl();
+  }
+
+  @Override
+  public String getCatalogName() {
+    return getCatalog().name();
+  }
+}

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/write/FlinkHiveTaskWriterBuilderTest.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/write/FlinkHiveTaskWriterBuilderTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.flink.write;
+
+import com.google.common.collect.Maps;
+import com.netease.arctic.flink.util.DataUtil;
+import com.netease.arctic.hive.catalog.HiveTableTestBase;
+import com.netease.arctic.table.PrimaryKeySpec;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.data.RowData;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.types.Types;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.time.LocalDateTime;
+
+/**
+ * This is a mix_hive table writer test.
+ */
+@RunWith(value = Parameterized.class)
+public class FlinkHiveTaskWriterBuilderTest extends HiveTableTestBase implements FlinkTaskWriterBaseTest {
+
+  public static final Schema HIVE_TABLE_SCHEMA = new Schema(
+      Types.NestedField.required(1, COLUMN_NAME_ID, Types.IntegerType.get()),
+      Types.NestedField.required(2, COLUMN_NAME_OP_TIME, Types.TimestampType.withoutZone()),
+      Types.NestedField.optional(3, COLUMN_NAME_OP_TIME_WITH_ZONE, Types.TimestampType.withZone()),
+      Types.NestedField.optional(4, COLUMN_NAME_D, Types.DecimalType.of(10, 0)),
+      Types.NestedField.required(5, COLUMN_NAME_NAME, Types.StringType.get())
+  );
+
+  public static final PrimaryKeySpec PRIMARY_KEY_SPEC = PrimaryKeySpec.builderFor(HIVE_TABLE_SCHEMA)
+      .addColumn(COLUMN_NAME_ID).build();
+
+  public FlinkHiveTaskWriterBuilderTest(
+      boolean keyedTable,
+      boolean partitionedTable) {
+    super(
+        HIVE_TABLE_SCHEMA,
+        keyedTable ?
+            PRIMARY_KEY_SPEC :
+            PrimaryKeySpec.noPrimaryKey(),
+        partitionedTable ?
+            PartitionSpec.builderFor(HIVE_TABLE_SCHEMA).identity(COLUMN_NAME_NAME).build() :
+            PartitionSpec.unpartitioned(),
+        Maps.newHashMap());
+  }
+
+  @Parameterized.Parameters(name = "keyedTable = {0}, partitionedTable = {1}")
+  public static Object[][] parameters() {
+    return new Object[][]{
+        {true, true},
+        {true, false},
+        {false, true},
+        {false, false}};
+  }
+
+  @Test
+  public void testPartialWriteToArctic() {
+    TableSchema flinkPartialSchema = TableSchema.builder()
+        .field(COLUMN_NAME_ID, DataTypes.INT())
+        .field(COLUMN_NAME_OP_TIME, DataTypes.TIMESTAMP())
+        .field(COLUMN_NAME_NAME, DataTypes.STRING())
+        .build();
+    RowData expected = DataUtil.toRowData(1000004, LocalDateTime.parse("2022-06-18T10:10:11.0"), "a");
+    testWriteAndReadArcticTable(getArcticTable(), flinkPartialSchema, expected);
+  }
+
+  @Test
+  public void testWriteOutOfOrderFieldsFromArctic() {
+    TableSchema flinkTableSchemaOutOfOrderFields = TableSchema.builder()
+        .field(COLUMN_NAME_D, DataTypes.STRING())
+        .field(COLUMN_NAME_ID, DataTypes.INT())
+        .field(COLUMN_NAME_OP_TIME, DataTypes.TIMESTAMP())
+        .field(COLUMN_NAME_NAME, DataTypes.STRING())
+        .build();
+    RowData expected = DataUtil.toRowData("dd", 1000004, LocalDateTime.parse("2022-06-18T10:10:11.0"), "a");
+    testWriteAndReadArcticTable(getArcticTable(), flinkTableSchemaOutOfOrderFields, expected);
+  }
+
+  @Override
+  public String getMetastoreUrl() {
+    return getCatalogUrl();
+  }
+
+  @Override
+  public String getCatalogName() {
+    return getCatalog().name();
+  }
+}

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/write/FlinkTaskWriterBaseTest.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/write/FlinkTaskWriterBaseTest.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.flink.write;
+
+import com.netease.arctic.flink.FlinkTableTestBase;
+import com.netease.arctic.flink.read.FlinkSplitPlanner;
+import com.netease.arctic.flink.read.hybrid.reader.RowDataReaderFunction;
+import com.netease.arctic.flink.read.hybrid.split.ArcticSplit;
+import com.netease.arctic.flink.read.source.DataIterator;
+import com.netease.arctic.io.ArcticFileIO;
+import com.netease.arctic.table.ArcticTable;
+import com.netease.arctic.table.KeyedTable;
+import com.netease.arctic.table.UnkeyedTable;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.flink.FlinkSchemaUtil;
+import org.apache.iceberg.flink.TableLoader;
+import org.apache.iceberg.flink.TestHelpers;
+import org.apache.iceberg.flink.source.FlinkInputFormat;
+import org.apache.iceberg.flink.source.FlinkSource;
+import org.apache.iceberg.io.TaskWriter;
+import org.apache.iceberg.io.WriteResult;
+import org.apache.iceberg.types.TypeUtil;
+import org.junit.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.netease.arctic.TableTestHelpers.PRIMARY_KEY_SPEC;
+
+public interface FlinkTaskWriterBaseTest extends FlinkTableTestBase {
+  Logger LOG = LoggerFactory.getLogger(FlinkTaskWriterBaseTest.class);
+
+  default void testWriteAndReadArcticTable(
+      ArcticTable arcticTable,
+      TableSchema flinkTableSchema,
+      RowData expected) {
+
+    // This is a partial-write schema from Flink engine view.
+    RowType rowType = (RowType) flinkTableSchema.toRowDataType().getLogicalType();
+
+    try (TaskWriter<RowData> taskWriter =
+             arcticTable.isKeyedTable() ?
+                 createKeyedTaskWriter((KeyedTable) arcticTable, rowType) :
+                 createUnkeyedTaskWriter((UnkeyedTable) arcticTable, rowType)) {
+      Assert.assertNotNull(taskWriter);
+
+      writeAndCommit(expected, taskWriter, arcticTable);
+
+      arcticTable.refresh();
+
+      // This is a partial-read schema from Flink engine view, should reassign schema id to selected-schema
+      Schema selectedSchema = TypeUtil.reassignIds(FlinkSchemaUtil.convert(flinkTableSchema), arcticTable.schema());
+
+      assertRecords(selectedSchema, arcticTable, expected, flinkTableSchema);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  default void assertRecords(
+      Schema selectedSchema,
+      ArcticTable arcticTable,
+      RowData expected,
+      TableSchema flinkTableSchema) throws IOException {
+    List<RowData> records;
+    if (arcticTable.isKeyedTable()) {
+      records =
+          recordsOfKeyedTable(
+              arcticTable.asKeyedTable(),
+              selectedSchema,
+              arcticTable.io());
+    } else {
+      records =
+          recordsOfUnkeyedTable(
+              getTableLoader(getCatalogName(), getMetastoreUrl(), arcticTable),
+              selectedSchema,
+              flinkTableSchema
+          );
+    }
+    Assert.assertEquals(1, records.size());
+    Assert.assertEquals(expected, records.get(0));
+  }
+
+  /**
+   * For asserting unkeyed table records.
+   */
+  String getMetastoreUrl();
+
+  /**
+   * For asserting unkeyed table records.
+   */
+  String getCatalogName();
+
+  default void writeAndCommit(RowData expected, TaskWriter<RowData> taskWriter, ArcticTable arcticTable) throws IOException {
+    taskWriter.write(expected);
+    WriteResult writerResult = taskWriter.complete();
+    boolean writeToBase = arcticTable.isUnkeyedTable();
+    commit(arcticTable, writerResult, writeToBase);
+    Assert.assertEquals(1, writerResult.dataFiles().length);
+  }
+
+  default List<RowData> recordsOfUnkeyedTable(
+      TableLoader tableLoader,
+      Schema projectedSchema,
+      TableSchema flinkTableSchema) throws IOException {
+    FlinkInputFormat inputFormat = FlinkSource.forRowData()
+        .tableLoader(tableLoader)
+        .project(flinkTableSchema)
+        .buildFormat();
+    return runFormat(inputFormat, FlinkSchemaUtil.convert(projectedSchema));
+  }
+
+  default List<RowData> recordsOfKeyedTable(
+      KeyedTable table,
+      Schema projectedSchema,
+      ArcticFileIO io) {
+    List<ArcticSplit> arcticSplits = FlinkSplitPlanner.planFullTable(table, new AtomicInteger(0));
+
+    RowDataReaderFunction rowDataReaderFunction =
+        new RowDataReaderFunction(
+            new Configuration(),
+            projectedSchema,
+            projectedSchema,
+            PRIMARY_KEY_SPEC,
+            null,
+            true,
+            io
+        );
+
+    List<RowData> actual = new ArrayList<>();
+    arcticSplits.forEach(split -> {
+      LOG.info("ArcticSplit {}.", split);
+      DataIterator<RowData> dataIterator = rowDataReaderFunction.createDataIterator(split);
+      while (dataIterator.hasNext()) {
+        RowData rowData = dataIterator.next();
+        LOG.info("{}", rowData);
+        actual.add(rowData);
+      }
+    });
+
+    return actual;
+  }
+
+  default List<RowData> runFormat(FlinkInputFormat inputFormat, RowType readRowType) throws IOException {
+    return TestHelpers.readRowData(inputFormat, readRowType);
+  }
+}

--- a/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/write/FlinkTaskWriterBaseTest.java
+++ b/flink/v1.14/flink/src/test/java/com/netease/arctic/flink/write/FlinkTaskWriterBaseTest.java
@@ -75,13 +75,14 @@ public interface FlinkTaskWriterBaseTest extends FlinkTableTestBase {
       // This is a partial-read schema from Flink engine view, should reassign schema id to selected-schema
       Schema selectedSchema = TypeUtil.reassignIds(FlinkSchemaUtil.convert(flinkTableSchema), arcticTable.schema());
 
-      assertRecords(selectedSchema, arcticTable, expected, flinkTableSchema);
+      assertRecords(arcticTable.schema(), selectedSchema, arcticTable, expected, flinkTableSchema);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
   }
 
   default void assertRecords(
+      Schema tableSchema,
       Schema selectedSchema,
       ArcticTable arcticTable,
       RowData expected,
@@ -91,6 +92,7 @@ public interface FlinkTaskWriterBaseTest extends FlinkTableTestBase {
       records =
           recordsOfKeyedTable(
               arcticTable.asKeyedTable(),
+              tableSchema,
               selectedSchema,
               arcticTable.io());
     } else {
@@ -136,6 +138,7 @@ public interface FlinkTaskWriterBaseTest extends FlinkTableTestBase {
 
   default List<RowData> recordsOfKeyedTable(
       KeyedTable table,
+      Schema tableSchema,
       Schema projectedSchema,
       ArcticFileIO io) {
     List<ArcticSplit> arcticSplits = FlinkSplitPlanner.planFullTable(table, new AtomicInteger(0));
@@ -143,7 +146,7 @@ public interface FlinkTaskWriterBaseTest extends FlinkTableTestBase {
     RowDataReaderFunction rowDataReaderFunction =
         new RowDataReaderFunction(
             new Configuration(),
-            projectedSchema,
+            tableSchema,
             projectedSchema,
             PRIMARY_KEY_SPEC,
             null,

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/FlinkTaskWriterBuilder.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/FlinkTaskWriterBuilder.java
@@ -144,9 +144,9 @@ public class FlinkTaskWriterBuilder implements TaskWriterBuilder<RowData> {
         new CommonOutputFileFactory(baseLocation, table.spec(), fileFormat, table.io(),
             encryptionManager, partitionId, taskId, transactionId);
     FileAppenderFactory<RowData> appenderFactory = TableTypeUtil.isHive(table) ?
-        new AdaptHiveFlinkAppenderFactory(schema, flinkSchema, table.properties(), table.spec()) :
+        new AdaptHiveFlinkAppenderFactory(selectSchema, flinkSchema, table.properties(), table.spec()) :
         new FlinkAppenderFactory(
-            schema, flinkSchema, table.properties(), table.spec());
+            selectSchema, flinkSchema, table.properties(), table.spec());
     return new FlinkBaseTaskWriter(
         fileFormat,
         appenderFactory,
@@ -170,17 +170,17 @@ public class FlinkTaskWriterBuilder implements TaskWriterBuilder<RowData> {
     KeyedTable keyedTable = table.asKeyedTable();
     Schema selectSchema = TypeUtil.reassignIds(
         FlinkSchemaUtil.convert(FlinkSchemaUtil.toSchema(flinkSchema)), keyedTable.baseTable().schema());
-    Schema changeSchemaWithMeta = SchemaUtil.changeWriteSchema(keyedTable.baseTable().schema());
-    RowType flinkSchemaWithMeta = FlinkSchemaUtil.convert(changeSchemaWithMeta);
+    Schema selectedSchemaWithMeta = SchemaUtil.changeWriteSchema(selectSchema);
+    RowType flinkSchemaWithMeta = FlinkSchemaUtil.convert(selectedSchemaWithMeta);
 
     OutputFileFactory outputFileFactory = new CommonOutputFileFactory(keyedTable.changeLocation(),
         keyedTable.spec(), fileFormat, keyedTable.io(), keyedTable.baseTable().encryption(), partitionId,
         taskId, transactionId);
     FileAppenderFactory<RowData> appenderFactory = TableTypeUtil.isHive(table) ?
-        new AdaptHiveFlinkAppenderFactory(changeSchemaWithMeta, flinkSchemaWithMeta,
+        new AdaptHiveFlinkAppenderFactory(selectedSchemaWithMeta, flinkSchemaWithMeta,
             keyedTable.properties(), keyedTable.spec()) :
         new FlinkAppenderFactory(
-            changeSchemaWithMeta, flinkSchemaWithMeta, keyedTable.properties(), keyedTable.spec());
+            selectedSchemaWithMeta, flinkSchemaWithMeta, keyedTable.properties(), keyedTable.spec());
     boolean upsert = table.isKeyedTable() && PropertyUtil.propertyAsBoolean(table.properties(),
         TableProperties.UPSERT_ENABLED, TableProperties.UPSERT_ENABLED_DEFAULT);
     return new FlinkChangeTaskWriter(

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/FlinkTableTestBase.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/FlinkTableTestBase.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.flink;
+
+import com.netease.arctic.flink.table.ArcticTableLoader;
+import com.netease.arctic.flink.write.ArcticRowDataTaskWriterFactory;
+import com.netease.arctic.table.ArcticTable;
+import com.netease.arctic.table.KeyedTable;
+import com.netease.arctic.table.TableIdentifier;
+import com.netease.arctic.table.UnkeyedTable;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.iceberg.AppendFiles;
+import org.apache.iceberg.io.TaskWriter;
+import org.apache.iceberg.io.WriteResult;
+
+import java.util.Arrays;
+
+/**
+ * This class contains flink table rowType schema and others,
+ * and will replace {@link FlinkTestBase} base class in the future.
+ */
+public interface FlinkTableTestBase {
+
+  default TaskWriter<RowData> createKeyedTaskWriter(
+      KeyedTable keyedTable,
+      RowType rowType) {
+    return createKeyedTaskWriter(keyedTable, rowType, false, 3);
+  }
+
+  default TaskWriter<RowData> createKeyedTaskWriter(
+      KeyedTable keyedTable,
+      RowType rowType,
+      boolean overwrite,
+      long mask) {
+    return createTaskWriter(keyedTable, rowType, overwrite, mask);
+  }
+
+  default TaskWriter<RowData> createUnkeyedTaskWriter(
+      UnkeyedTable unkeyedTable,
+      RowType rowType) {
+    return createTaskWriter(unkeyedTable, rowType, false, 3);
+  }
+
+  default TaskWriter<RowData> createTaskWriter(
+      ArcticTable arcticTable,
+      RowType rowType,
+      boolean overwrite,
+      long mask) {
+    ArcticRowDataTaskWriterFactory taskWriterFactory =
+        new ArcticRowDataTaskWriterFactory(arcticTable, rowType, overwrite);
+    taskWriterFactory.setMask(mask);
+    taskWriterFactory.initialize(0, 0);
+    return taskWriterFactory.create();
+  }
+
+  default void commit(ArcticTable arcticTable, WriteResult result, boolean base) {
+    if (arcticTable.isKeyedTable()) {
+      KeyedTable keyedTable = arcticTable.asKeyedTable();
+      if (base) {
+        AppendFiles baseAppend = keyedTable.baseTable().newAppend();
+        Arrays.stream(result.dataFiles()).forEach(baseAppend::appendFile);
+        baseAppend.commit();
+      } else {
+        AppendFiles changeAppend = keyedTable.changeTable().newAppend();
+        Arrays.stream(result.dataFiles()).forEach(changeAppend::appendFile);
+        changeAppend.commit();
+      }
+    } else {
+      if (!base) {
+        throw new IllegalArgumentException(
+            String.format("arctic table %s is a unkeyed table, can't commit to change table", arcticTable.name()));
+      }
+      UnkeyedTable unkeyedTable = arcticTable.asUnkeyedTable();
+      AppendFiles baseAppend = unkeyedTable.newAppend();
+      Arrays.stream(result.dataFiles()).forEach(baseAppend::appendFile);
+      baseAppend.commit();
+    }
+  }
+
+  default ArcticTableLoader getTableLoader(String catalogName, String metastoreUrl, ArcticTable arcticTable) {
+    TableIdentifier identifier = TableIdentifier.of(
+        catalogName,
+        arcticTable.id().getDatabase(),
+        arcticTable.id().getTableName());
+    InternalCatalogBuilder internalCatalogBuilder =
+        InternalCatalogBuilder.builder().metastoreUrl(metastoreUrl);
+    return ArcticTableLoader.of(identifier, internalCatalogBuilder, arcticTable.properties());
+  }
+}

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/write/FlinkArcticTaskWriterBuilderTest.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/write/FlinkArcticTaskWriterBuilderTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.flink.write;
+
+import com.netease.arctic.ams.api.properties.TableFormat;
+import com.netease.arctic.catalog.TableTestBase;
+import com.netease.arctic.flink.util.DataUtil;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.data.RowData;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.time.LocalDateTime;
+
+import static com.netease.arctic.TableTestHelpers.COLUMN_NAME_ID;
+import static com.netease.arctic.TableTestHelpers.COLUMN_NAME_NAME;
+import static com.netease.arctic.TableTestHelpers.COLUMN_NAME_OP_TIME;
+import static com.netease.arctic.TableTestHelpers.COLUMN_NAME_TS;
+
+/**
+ * This is a mix_iceberg writer test.
+ */
+@RunWith(value = Parameterized.class)
+public class FlinkArcticTaskWriterBuilderTest extends TableTestBase implements FlinkTaskWriterBaseTest {
+
+  public FlinkArcticTaskWriterBuilderTest(
+      boolean keyedTable,
+      boolean partitionedTable) {
+    super(TableFormat.MIXED_ICEBERG, keyedTable, partitionedTable);
+  }
+
+  @Parameterized.Parameters(name = "keyedTable = {0}, partitionedTable = {1}")
+  public static Object[][] parameters() {
+    return new Object[][]{
+        {true, true},
+        {true, false},
+        {false, true},
+        {false, false}};
+  }
+
+  @Test
+  public void testWriteToArcticWithPartialSchema() {
+    TableSchema flinkPartialSchema = TableSchema.builder()
+        .field(COLUMN_NAME_ID, DataTypes.INT())
+        .field(COLUMN_NAME_NAME, DataTypes.STRING())
+        .field(COLUMN_NAME_OP_TIME, DataTypes.TIMESTAMP())
+        .build();
+    RowData expected = DataUtil.toRowData(1000004, "a", LocalDateTime.parse("2022-06-18T10:10:11.0"));
+    testWriteAndReadArcticTable(getArcticTable(), flinkPartialSchema, expected);
+  }
+
+  /**
+   * The order of flink table schema fields is different from that of arctic table schema fields.
+   */
+  @Test
+  public void testWriteToArcticWithOutOfOrderFieldsAndPK() {
+    TableSchema flinkTableSchemaOutOfOrderFields = TableSchema.builder()
+        .field(COLUMN_NAME_TS, DataTypes.BIGINT())
+        .field(COLUMN_NAME_ID, DataTypes.INT())
+        .field(COLUMN_NAME_NAME, DataTypes.STRING())
+        .field(COLUMN_NAME_OP_TIME, DataTypes.TIMESTAMP())
+        .build();
+    RowData expected = DataUtil.toRowData(System.currentTimeMillis(), 1000004, "a", LocalDateTime.parse("2022-06-18T10:10:11.0"));
+    testWriteAndReadArcticTable(getArcticTable(), flinkTableSchemaOutOfOrderFields, expected);
+  }
+
+  @Override
+  public String getMetastoreUrl() {
+    return getCatalogUrl();
+  }
+
+  @Override
+  public String getCatalogName() {
+    return getCatalog().name();
+  }
+}

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/write/FlinkHiveTaskWriterBuilderTest.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/write/FlinkHiveTaskWriterBuilderTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.flink.write;
+
+import com.google.common.collect.Maps;
+import com.netease.arctic.flink.util.DataUtil;
+import com.netease.arctic.hive.catalog.HiveTableTestBase;
+import com.netease.arctic.table.PrimaryKeySpec;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.data.RowData;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.types.Types;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.time.LocalDateTime;
+
+/**
+ * This is a mix_hive table writer test.
+ */
+@RunWith(value = Parameterized.class)
+public class FlinkHiveTaskWriterBuilderTest extends HiveTableTestBase implements FlinkTaskWriterBaseTest {
+
+  public static final Schema HIVE_TABLE_SCHEMA = new Schema(
+      Types.NestedField.required(1, COLUMN_NAME_ID, Types.IntegerType.get()),
+      Types.NestedField.required(2, COLUMN_NAME_OP_TIME, Types.TimestampType.withoutZone()),
+      Types.NestedField.optional(3, COLUMN_NAME_OP_TIME_WITH_ZONE, Types.TimestampType.withZone()),
+      Types.NestedField.optional(4, COLUMN_NAME_D, Types.DecimalType.of(10, 0)),
+      Types.NestedField.required(5, COLUMN_NAME_NAME, Types.StringType.get())
+  );
+
+  public static final PrimaryKeySpec PRIMARY_KEY_SPEC = PrimaryKeySpec.builderFor(HIVE_TABLE_SCHEMA)
+      .addColumn(COLUMN_NAME_ID).build();
+
+  public FlinkHiveTaskWriterBuilderTest(
+      boolean keyedTable,
+      boolean partitionedTable) {
+    super(
+        HIVE_TABLE_SCHEMA,
+        keyedTable ?
+            PRIMARY_KEY_SPEC :
+            PrimaryKeySpec.noPrimaryKey(),
+        partitionedTable ?
+            PartitionSpec.builderFor(HIVE_TABLE_SCHEMA).identity(COLUMN_NAME_NAME).build() :
+            PartitionSpec.unpartitioned(),
+        Maps.newHashMap());
+  }
+
+  @Parameterized.Parameters(name = "keyedTable = {0}, partitionedTable = {1}")
+  public static Object[][] parameters() {
+    return new Object[][]{
+        {true, true},
+        {true, false},
+        {false, true},
+        {false, false}};
+  }
+
+  @Test
+  public void testPartialWriteToArctic() {
+    TableSchema flinkPartialSchema = TableSchema.builder()
+        .field(COLUMN_NAME_ID, DataTypes.INT())
+        .field(COLUMN_NAME_OP_TIME, DataTypes.TIMESTAMP())
+        .field(COLUMN_NAME_NAME, DataTypes.STRING())
+        .build();
+    RowData expected = DataUtil.toRowData(1000004, LocalDateTime.parse("2022-06-18T10:10:11.0"), "a");
+    testWriteAndReadArcticTable(getArcticTable(), flinkPartialSchema, expected);
+  }
+
+  @Test
+  public void testWriteOutOfOrderFieldsFromArctic() {
+    TableSchema flinkTableSchemaOutOfOrderFields = TableSchema.builder()
+        .field(COLUMN_NAME_D, DataTypes.STRING())
+        .field(COLUMN_NAME_ID, DataTypes.INT())
+        .field(COLUMN_NAME_OP_TIME, DataTypes.TIMESTAMP())
+        .field(COLUMN_NAME_NAME, DataTypes.STRING())
+        .build();
+    RowData expected = DataUtil.toRowData("dd", 1000004, LocalDateTime.parse("2022-06-18T10:10:11.0"), "a");
+    testWriteAndReadArcticTable(getArcticTable(), flinkTableSchemaOutOfOrderFields, expected);
+  }
+
+  @Override
+  public String getMetastoreUrl() {
+    return getCatalogUrl();
+  }
+
+  @Override
+  public String getCatalogName() {
+    return getCatalog().name();
+  }
+}

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/write/FlinkTaskWriterBaseTest.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/write/FlinkTaskWriterBaseTest.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.flink.write;
+
+import com.netease.arctic.flink.FlinkTableTestBase;
+import com.netease.arctic.flink.read.FlinkSplitPlanner;
+import com.netease.arctic.flink.read.hybrid.reader.RowDataReaderFunction;
+import com.netease.arctic.flink.read.hybrid.split.ArcticSplit;
+import com.netease.arctic.flink.read.source.DataIterator;
+import com.netease.arctic.io.ArcticFileIO;
+import com.netease.arctic.table.ArcticTable;
+import com.netease.arctic.table.KeyedTable;
+import com.netease.arctic.table.UnkeyedTable;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.flink.FlinkSchemaUtil;
+import org.apache.iceberg.flink.TableLoader;
+import org.apache.iceberg.flink.TestHelpers;
+import org.apache.iceberg.flink.source.FlinkInputFormat;
+import org.apache.iceberg.flink.source.FlinkSource;
+import org.apache.iceberg.io.TaskWriter;
+import org.apache.iceberg.io.WriteResult;
+import org.apache.iceberg.types.TypeUtil;
+import org.junit.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.netease.arctic.TableTestHelpers.PRIMARY_KEY_SPEC;
+
+public interface FlinkTaskWriterBaseTest extends FlinkTableTestBase {
+  Logger LOG = LoggerFactory.getLogger(FlinkTaskWriterBaseTest.class);
+
+  default void testWriteAndReadArcticTable(
+      ArcticTable arcticTable,
+      TableSchema flinkTableSchema,
+      RowData expected) {
+
+    // This is a partial-write schema from Flink engine view.
+    RowType rowType = (RowType) flinkTableSchema.toRowDataType().getLogicalType();
+
+    try (TaskWriter<RowData> taskWriter =
+             arcticTable.isKeyedTable() ?
+                 createKeyedTaskWriter((KeyedTable) arcticTable, rowType) :
+                 createUnkeyedTaskWriter((UnkeyedTable) arcticTable, rowType)) {
+      Assert.assertNotNull(taskWriter);
+
+      writeAndCommit(expected, taskWriter, arcticTable);
+
+      arcticTable.refresh();
+
+      // This is a partial-read schema from Flink engine view, should reassign schema id to selected-schema
+      Schema selectedSchema = TypeUtil.reassignIds(FlinkSchemaUtil.convert(flinkTableSchema), arcticTable.schema());
+
+      assertRecords(selectedSchema, arcticTable, expected, flinkTableSchema);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  default void assertRecords(
+      Schema selectedSchema,
+      ArcticTable arcticTable,
+      RowData expected,
+      TableSchema flinkTableSchema) throws IOException {
+    List<RowData> records;
+    if (arcticTable.isKeyedTable()) {
+      records =
+          recordsOfKeyedTable(
+              arcticTable.asKeyedTable(),
+              selectedSchema,
+              arcticTable.io());
+    } else {
+      records =
+          recordsOfUnkeyedTable(
+              getTableLoader(getCatalogName(), getMetastoreUrl(), arcticTable),
+              selectedSchema,
+              flinkTableSchema
+          );
+    }
+    Assert.assertEquals(1, records.size());
+    Assert.assertEquals(expected, records.get(0));
+  }
+
+  /**
+   * For asserting unkeyed table records.
+   */
+  String getMetastoreUrl();
+
+  /**
+   * For asserting unkeyed table records.
+   */
+  String getCatalogName();
+
+  default void writeAndCommit(RowData expected, TaskWriter<RowData> taskWriter, ArcticTable arcticTable) throws IOException {
+    taskWriter.write(expected);
+    WriteResult writerResult = taskWriter.complete();
+    boolean writeToBase = arcticTable.isUnkeyedTable();
+    commit(arcticTable, writerResult, writeToBase);
+    Assert.assertEquals(1, writerResult.dataFiles().length);
+  }
+
+  default List<RowData> recordsOfUnkeyedTable(
+      TableLoader tableLoader,
+      Schema projectedSchema,
+      TableSchema flinkTableSchema) throws IOException {
+    FlinkInputFormat inputFormat = FlinkSource.forRowData()
+        .tableLoader(tableLoader)
+        .project(flinkTableSchema)
+        .buildFormat();
+    return runFormat(inputFormat, FlinkSchemaUtil.convert(projectedSchema));
+  }
+
+  default List<RowData> recordsOfKeyedTable(
+      KeyedTable table,
+      Schema projectedSchema,
+      ArcticFileIO io) {
+    List<ArcticSplit> arcticSplits = FlinkSplitPlanner.planFullTable(table, new AtomicInteger(0));
+
+    RowDataReaderFunction rowDataReaderFunction =
+        new RowDataReaderFunction(
+            new Configuration(),
+            projectedSchema,
+            projectedSchema,
+            PRIMARY_KEY_SPEC,
+            null,
+            true,
+            io
+        );
+
+    List<RowData> actual = new ArrayList<>();
+    arcticSplits.forEach(split -> {
+      LOG.info("ArcticSplit {}.", split);
+      DataIterator<RowData> dataIterator = rowDataReaderFunction.createDataIterator(split);
+      while (dataIterator.hasNext()) {
+        RowData rowData = dataIterator.next();
+        LOG.info("{}", rowData);
+        actual.add(rowData);
+      }
+    });
+
+    return actual;
+  }
+
+  default List<RowData> runFormat(FlinkInputFormat inputFormat, RowType readRowType) throws IOException {
+    return TestHelpers.readRowData(inputFormat, readRowType);
+  }
+}

--- a/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/write/FlinkTaskWriterBaseTest.java
+++ b/flink/v1.15/flink/src/test/java/com/netease/arctic/flink/write/FlinkTaskWriterBaseTest.java
@@ -75,13 +75,14 @@ public interface FlinkTaskWriterBaseTest extends FlinkTableTestBase {
       // This is a partial-read schema from Flink engine view, should reassign schema id to selected-schema
       Schema selectedSchema = TypeUtil.reassignIds(FlinkSchemaUtil.convert(flinkTableSchema), arcticTable.schema());
 
-      assertRecords(selectedSchema, arcticTable, expected, flinkTableSchema);
+      assertRecords(arcticTable.schema(), selectedSchema, arcticTable, expected, flinkTableSchema);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
   }
 
   default void assertRecords(
+      Schema tableSchema,
       Schema selectedSchema,
       ArcticTable arcticTable,
       RowData expected,
@@ -91,6 +92,7 @@ public interface FlinkTaskWriterBaseTest extends FlinkTableTestBase {
       records =
           recordsOfKeyedTable(
               arcticTable.asKeyedTable(),
+              tableSchema,
               selectedSchema,
               arcticTable.io());
     } else {
@@ -136,6 +138,7 @@ public interface FlinkTaskWriterBaseTest extends FlinkTableTestBase {
 
   default List<RowData> recordsOfKeyedTable(
       KeyedTable table,
+      Schema tableSchema,
       Schema projectedSchema,
       ArcticFileIO io) {
     List<ArcticSplit> arcticSplits = FlinkSplitPlanner.planFullTable(table, new AtomicInteger(0));
@@ -143,7 +146,7 @@ public interface FlinkTaskWriterBaseTest extends FlinkTableTestBase {
     RowDataReaderFunction rowDataReaderFunction =
         new RowDataReaderFunction(
             new Configuration(),
-            projectedSchema,
+            tableSchema,
             projectedSchema,
             PRIMARY_KEY_SPEC,
             null,

--- a/hive/src/main/java/com/netease/arctic/hive/ArcticHiveClientPool.java
+++ b/hive/src/main/java/com/netease/arctic/hive/ArcticHiveClientPool.java
@@ -50,7 +50,7 @@ public class ArcticHiveClientPool extends ClientPoolImpl<HMSClient, TException> 
     super(poolSize, TTransportException.class, true);
     this.hiveConf = new HiveConf(tableMetaStore.getConfiguration(), ArcticHiveClientPool.class);
     this.hiveConf.addResource(tableMetaStore.getConfiguration());
-    this.hiveConf.addResource(tableMetaStore.getHiveSiteLocation().orElse(null));
+    tableMetaStore.getHiveSiteLocation().ifPresent(this.hiveConf::addResource);
     this.metaStore = tableMetaStore;
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->
fix: #1277 

Due to initiating a task writer with an incorrect schema when writing partial field data into a mixed format table, task writers will have a field type cast exception.
For example: 
```
Arctic Table Schema:
id int,
name string,
age,
opt timestamp

Flink Table Schema:
age,
id,
opt timestamp
```
Flink task only writes three field data into an arctic table and also the order of fields is different from the arctic table's fields.
## Brief change log

  - *Modify the correct schema in the FlinkTaskWriterBuilder class*
  - *The flink 1.12, 1.14, and 1.15 versions are affected.*
  - *Add the mixed-hive and mixed-iceberg table writing and reading tests*

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
