### PR TITLE
Replace the fastjson of the ArcticMetaStore class in ams-server with jackson

### DIFF
--- a/spark/v3.1/spark/src/main/java/com/netease/arctic/spark/reader/ArcticSparkKeyedDataReader.java
+++ b/spark/v3.1/spark/src/main/java/com/netease/arctic/spark/reader/ArcticSparkKeyedDataReader.java
@@ -44,7 +44,7 @@ public class ArcticSparkKeyedDataReader extends AbstractAdaptHiveArcticDataReade
       String nameMapping,
       boolean caseSensitive) {
     super(fileIO, tableSchema, projectedSchema, primaryKeySpec, nameMapping, caseSensitive,
-        ArcticSparkUtils::convertConstant, false);
+        ArcticSparkUtils::convertConstant, true);
   }
 
   @Override
@@ -58,7 +58,8 @@ public class ArcticSparkKeyedDataReader extends AbstractAdaptHiveArcticDataReade
   protected Function<Schema, Function<InternalRow, StructLike>> toStructLikeFunction() {
     return schema -> {
       final StructType structType = SparkSchemaUtil.convert(schema);
-      return row -> new SparkInternalRowWrapper(structType).wrap(row);
+      SparkInternalRowWrapper wrapper = new SparkInternalRowWrapper(structType);
+      return row -> wrapper.wrap(row);
     };
   }
 }

--- a/spark/v3.1/spark/src/main/java/com/netease/arctic/spark/reader/ArcticSparkUnkeyedDataReader.java
+++ b/spark/v3.1/spark/src/main/java/com/netease/arctic/spark/reader/ArcticSparkUnkeyedDataReader.java
@@ -42,7 +42,7 @@ public class ArcticSparkUnkeyedDataReader extends AbstractAdaptHiveIcebergDataRe
       String nameMapping,
       boolean caseSensitive) {
     super(fileIO, tableSchema, projectedSchema, nameMapping, caseSensitive,
-        ArcticSparkUtils::convertConstant, false);
+        ArcticSparkUtils::convertConstant, true);
   }
 
   @Override
@@ -56,7 +56,8 @@ public class ArcticSparkUnkeyedDataReader extends AbstractAdaptHiveIcebergDataRe
   protected Function<Schema, Function<InternalRow, StructLike>> toStructLikeFunction() {
     return schema -> {
       final StructType structType = SparkSchemaUtil.convert(schema);
-      return row -> new SparkInternalRowWrapper(structType).wrap(row);
+      SparkInternalRowWrapper wrapper = new SparkInternalRowWrapper(structType);
+      return row -> wrapper.wrap(row);
     };
   }
 }

--- a/spark/v3.3/spark/src/main/java/com/netease/arctic/spark/reader/ArcticSparkKeyedDataReader.java
+++ b/spark/v3.3/spark/src/main/java/com/netease/arctic/spark/reader/ArcticSparkKeyedDataReader.java
@@ -45,7 +45,7 @@ public class ArcticSparkKeyedDataReader extends AbstractAdaptHiveArcticDataReade
       String nameMapping,
       boolean caseSensitive) {
     super(fileIO, tableSchema, projectedSchema, primaryKeySpec, nameMapping, caseSensitive,
-        ArcticSparkUtils::convertConstant, false);
+        ArcticSparkUtils::convertConstant, true);
   }
 
   @Override
@@ -59,7 +59,8 @@ public class ArcticSparkKeyedDataReader extends AbstractAdaptHiveArcticDataReade
   protected Function<Schema, Function<InternalRow, StructLike>> toStructLikeFunction() {
     return schema -> {
       final StructType structType = SparkSchemaUtil.convert(schema);
-      return row -> new SparkInternalRowWrapper(structType).wrap(row);
+      SparkInternalRowWrapper wrapper = new SparkInternalRowWrapper(structType);
+      return row -> wrapper.wrap(row);
     };
   }
 }

--- a/spark/v3.3/spark/src/main/java/com/netease/arctic/spark/reader/ArcticSparkUnkeyedDataReader.java
+++ b/spark/v3.3/spark/src/main/java/com/netease/arctic/spark/reader/ArcticSparkUnkeyedDataReader.java
@@ -43,7 +43,7 @@ public class ArcticSparkUnkeyedDataReader extends AbstractAdaptHiveIcebergDataRe
       String nameMapping,
       boolean caseSensitive) {
     super(fileIO, tableSchema, projectedSchema, nameMapping, caseSensitive,
-        ArcticSparkUtils::convertConstant, false);
+        ArcticSparkUtils::convertConstant, true);
   }
 
   @Override
@@ -57,7 +57,8 @@ public class ArcticSparkUnkeyedDataReader extends AbstractAdaptHiveIcebergDataRe
   protected Function<Schema, Function<InternalRow, StructLike>> toStructLikeFunction() {
     return schema -> {
       final StructType structType = SparkSchemaUtil.convert(schema);
-      return row -> new SparkInternalRowWrapper(structType).wrap(row);
+      SparkInternalRowWrapper wrapper = new SparkInternalRowWrapper(structType);
+      return row -> wrapper.wrap(row);
     };
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
There are many high-risk vulnerabilities in the previous version of fastjosn,We need to replace fastjson with jackson

## Brief change log
Replace the fastjson of the ArcticMetaStore class in ams-server with jackson,

## How was this patch tested?
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduces a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
