### PR TITLE
[ARCTIC-1783][lookup] The primary key serialization exception occurs when the primary key definition is different from the schema fields order

### DIFF
--- a/core/src/main/java/com/netease/arctic/utils/SchemaUtil.java
+++ b/core/src/main/java/com/netease/arctic/utils/SchemaUtil.java
@@ -21,6 +21,7 @@ package com.netease.arctic.utils;
 import com.netease.arctic.table.MetadataColumns;
 import com.netease.arctic.table.PrimaryKeySpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.TypeUtil;
@@ -28,6 +29,7 @@ import org.apache.iceberg.types.Types;
 
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class SchemaUtil {
 
@@ -66,5 +68,24 @@ public class SchemaUtil {
     });
 
     return new Schema(schemaId, fields, identifierFieldIds);
+  }
+
+  /**
+   * Create an Iceberg Schema {@link Schema} from a {@link Schema} based on the given order of fieldNames.
+   * <p> {@link Schema#select(String...)} is not used because it returns a new Schema
+   * whose fields are not in the same order as the incoming fields.
+   *
+   * @param baseSchema a Schema on which loading is based
+   * @param fieldNames a list of field names
+   * @return a new Schema on which contain the fieldNames of the base schema.
+   */
+  public static Schema selectInOrder(Schema baseSchema, List<String> fieldNames) {
+    Preconditions.checkNotNull(fieldNames);
+    Preconditions.checkNotNull(baseSchema);
+
+    int schemaId = baseSchema.schemaId();
+    List<Types.NestedField> fields = fieldNames.stream().map(baseSchema::findField).collect(Collectors.toList());
+
+    return new Schema(schemaId, fields);
   }
 }

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/lookup/RocksDBCacheState.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/lookup/RocksDBCacheState.java
@@ -71,6 +71,7 @@ public abstract class RocksDBCacheState<V> {
   protected BinaryRowDataSerializerWrapper valueSerializer;
   private ExecutorService writeRocksDBService;
   private final AtomicBoolean initialized = new AtomicBoolean(false);
+  private final AtomicBoolean running = new AtomicBoolean(true);
   protected Queue<LookupRecord> lookupRecordsQueue;
 
   private final int writeRocksDBThreadNum;
@@ -210,6 +211,7 @@ public abstract class RocksDBCacheState<V> {
       writeRocksDBService.shutdown();
       writeRocksDBService = null;
     }
+    running.set(false);
     if (lookupRecordsQueue != null) {
       lookupRecordsQueue.clear();
       lookupRecordsQueue = null;
@@ -264,7 +266,7 @@ public abstract class RocksDBCacheState<V> {
     public void run() {
       LOG.info("{} starting.", name);
       try {
-        while (!initialized.get()) {
+        while (running.get() && !initialized.get()) {
           LookupRecord record = lookupRecordsQueue.poll();
           if (record != null) {
             switch (record.opType()) {

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/lookup/UniqueIndexTable.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/lookup/UniqueIndexTable.java
@@ -18,6 +18,7 @@
 
 package com.netease.arctic.flink.lookup;
 
+import com.netease.arctic.utils.SchemaUtil;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.types.RowKind;
 import org.apache.iceberg.Schema;
@@ -133,7 +134,7 @@ public class UniqueIndexTable implements KVTable<RowData> {
 
   protected BinaryRowDataSerializerWrapper createKeySerializer(
       Schema arcticTableSchema, List<String> keys) {
-    Schema keySchema = arcticTableSchema.select(keys);
+    Schema keySchema = SchemaUtil.selectInOrder(arcticTableSchema, keys);
     return new BinaryRowDataSerializerWrapper(keySchema);
   }
 

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/lookup/RocksDBCacheState.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/lookup/RocksDBCacheState.java
@@ -71,6 +71,7 @@ public abstract class RocksDBCacheState<V> {
   protected BinaryRowDataSerializerWrapper valueSerializer;
   private ExecutorService writeRocksDBService;
   private final AtomicBoolean initialized = new AtomicBoolean(false);
+  private final AtomicBoolean running = new AtomicBoolean(true);
   protected Queue<LookupRecord> lookupRecordsQueue;
 
   private final int writeRocksDBThreadNum;
@@ -210,6 +211,7 @@ public abstract class RocksDBCacheState<V> {
       writeRocksDBService.shutdown();
       writeRocksDBService = null;
     }
+    running.set(false);
     if (lookupRecordsQueue != null) {
       lookupRecordsQueue.clear();
       lookupRecordsQueue = null;
@@ -264,7 +266,7 @@ public abstract class RocksDBCacheState<V> {
     public void run() {
       LOG.info("{} starting.", name);
       try {
-        while (!initialized.get()) {
+        while (running.get() && !initialized.get()) {
           LookupRecord record = lookupRecordsQueue.poll();
           if (record != null) {
             switch (record.opType()) {

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/lookup/UniqueIndexTable.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/lookup/UniqueIndexTable.java
@@ -18,6 +18,7 @@
 
 package com.netease.arctic.flink.lookup;
 
+import com.netease.arctic.utils.SchemaUtil;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.types.RowKind;
 import org.apache.iceberg.Schema;
@@ -133,7 +134,7 @@ public class UniqueIndexTable implements KVTable<RowData> {
 
   protected BinaryRowDataSerializerWrapper createKeySerializer(
       Schema arcticTableSchema, List<String> keys) {
-    Schema keySchema = arcticTableSchema.select(keys);
+    Schema keySchema = SchemaUtil.selectInOrder(arcticTableSchema, keys);
     return new BinaryRowDataSerializerWrapper(keySchema);
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

fixed: #1783 


## Brief change log

  - *Adjust the order of the primary keys and join keys when creating unique and join keys mapping index*
  - *The Flink 1.15 and 1.14 versions are affected.*
  - *Avoid NPE if the initialization process fails*
  - *Add some tests*

## How was this patch tested?
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
