### PR TITLE
[ARCTIC-1783][lookup] Ensure that projection schemas are in the same order

### DIFF
--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/ArcticDynamicSource.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/ArcticDynamicSource.java
@@ -29,6 +29,7 @@ import com.netease.arctic.flink.util.FilterUtil;
 import com.netease.arctic.flink.util.IcebergAndFlinkFilters;
 import com.netease.arctic.hive.io.reader.AbstractAdaptHiveArcticDataReader;
 import com.netease.arctic.table.ArcticTable;
+import com.netease.arctic.utils.SchemaUtil;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.api.DataTypes;
@@ -328,7 +329,7 @@ public class ArcticDynamicSource implements ScanTableSource, SupportsFilterPushD
                   index ->
                       arcticTable.schema().columns().get(index).name())
               .collect(Collectors.toList());
-      projectedSchema = arcticTableSchema.select(projectedFieldNames);
+      projectedSchema = SchemaUtil.selectInOrder(arcticTableSchema, projectedFieldNames);
       LOG.info(
           "projected schema {}.\n table schema {}.",
           projectedSchema,

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/ArcticDynamicSource.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/ArcticDynamicSource.java
@@ -29,6 +29,7 @@ import com.netease.arctic.flink.util.FilterUtil;
 import com.netease.arctic.flink.util.IcebergAndFlinkFilters;
 import com.netease.arctic.hive.io.reader.AbstractAdaptHiveArcticDataReader;
 import com.netease.arctic.table.ArcticTable;
+import com.netease.arctic.utils.SchemaUtil;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.api.DataTypes;
@@ -328,7 +329,7 @@ public class ArcticDynamicSource implements ScanTableSource, SupportsFilterPushD
                   index ->
                       arcticTable.schema().columns().get(index).name())
               .collect(Collectors.toList());
-      projectedSchema = arcticTableSchema.select(projectedFieldNames);
+      projectedSchema = SchemaUtil.selectInOrder(arcticTableSchema, projectedFieldNames);
       LOG.info(
           "projected schema {}.\n table schema {}.",
           projectedSchema,


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

fixed: #1783 
## Brief change log

- Adjust the order of the projected fields when creating projected schema from base schema;
- The Flink 1.15 and 1.14 versions are affected.

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
