### PR TITLE
[ARCTIC-1796] [Bug]: the configuration of "local.spark.sql.session.timeZone" caused a time difference of 8 time zones in the processing of time fields in the terminal

### DIFF
--- a/dist/src/main/arctic-bin/conf/config.yaml
+++ b/dist/src/main/arctic-bin/conf/config.yaml
@@ -62,7 +62,6 @@ ams:
 
   terminal:
     backend: local
-  #  local.spark.sql.session.timeZone: UTC
     local.spark.sql.iceberg.handle-timestamp-without-timezone: false
 
 #  Kyuubi terminal backend configuration.

--- a/dist/src/main/arctic-bin/conf/config.yaml
+++ b/dist/src/main/arctic-bin/conf/config.yaml
@@ -62,7 +62,7 @@ ams:
 
   terminal:
     backend: local
-    local.spark.sql.session.timeZone: UTC
+  #  local.spark.sql.session.timeZone: UTC
     local.spark.sql.iceberg.handle-timestamp-without-timezone: false
 
 #  Kyuubi terminal backend configuration.

--- a/docs/admin-guides/deployment.md
+++ b/docs/admin-guides/deployment.md
@@ -195,7 +195,6 @@ The configuration for kyuubi mode can refer to: [Using Kyuubi with Terminal](../
 ams:
   terminal:
     backend: local
-    local.spark.sql.session.timeZone: UTC
     local.spark.sql.iceberg.handle-timestamp-without-timezone: false
     # When the catalog type is Hive, it automatically uses the Spark session catalog to access Hive tables.
     local.using-session-catalog-for-hive: true


### PR DESCRIPTION
fix #1796 

## Why are the changes needed?

1. The configuration of "local.spark.sql.session.timeZone" caused a time difference of 8 time zones in the processing of time fields in the terminal.

## Brief change log

- remove the config  "local.spark.sql.session.timeZone: UTC"


## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
