### PR TITLE
[AMORO-1807] When I upgrade a hive table and it fails, it deletes the original hive table

### DIFF
--- a/hive/src/main/java/com/netease/arctic/hive/catalog/ArcticHiveCatalog.java
+++ b/hive/src/main/java/com/netease/arctic/hive/catalog/ArcticHiveCatalog.java
@@ -223,6 +223,8 @@ public class ArcticHiveCatalog extends BasicArcticCatalog {
     @Override
     protected void doRollbackCreateTable(TableMeta meta) {
       if (allowExistedHiveTable) {
+        LOG.info("No need to drop hive table {}.{}", meta.getTableIdentifier().getDatabase(),
+            meta.getTableIdentifier().getTableName());
         tables.dropTableByMeta(meta, false);
       } else {
         super.doRollbackCreateTable(meta);

--- a/hive/src/main/java/com/netease/arctic/hive/catalog/ArcticHiveCatalog.java
+++ b/hive/src/main/java/com/netease/arctic/hive/catalog/ArcticHiveCatalog.java
@@ -123,7 +123,7 @@ public class ArcticHiveCatalog extends BasicArcticCatalog {
 
   public void dropTableButNotDropHiveTable(TableIdentifier tableIdentifier) {
     TableMeta meta = getArcticTableMeta(tableIdentifier);
-    super.doDropTable(meta, false);
+    ((MixedHiveTables)tables).dropTableMetaButNotDropHiveTable(meta);
   }
 
   @Override

--- a/hive/src/main/java/com/netease/arctic/hive/catalog/ArcticHiveCatalog.java
+++ b/hive/src/main/java/com/netease/arctic/hive/catalog/ArcticHiveCatalog.java
@@ -226,18 +226,6 @@ public class ArcticHiveCatalog extends BasicArcticCatalog {
         tables.dropTableByMeta(meta, false);
       } else {
         super.doRollbackCreateTable(meta);
-        try {
-          hiveClientPool.run(client -> {
-            client.dropTable(
-                meta.getTableIdentifier().getDatabase(),
-                meta.getTableIdentifier().getTableName(),
-                true,
-                true);
-            return null;
-          });
-        } catch (TException | InterruptedException e) {
-          LOG.warn("Failed to drop hive table while rolling back create table operation", e);
-        }
       }
     }
 

--- a/hive/src/main/java/com/netease/arctic/hive/catalog/ArcticHiveCatalog.java
+++ b/hive/src/main/java/com/netease/arctic/hive/catalog/ArcticHiveCatalog.java
@@ -122,7 +122,25 @@ public class ArcticHiveCatalog extends BasicArcticCatalog {
   }
 
   public void dropTableButNotDropHiveTable(TableIdentifier tableIdentifier) {
+    try {
+      hiveClientPool.run(client -> {
+        org.apache.hadoop.hive.metastore.api.Table hiveTable = client.getTable(
+            tableIdentifier.getDatabase(),
+            tableIdentifier.getTableName());
+        Map<String, String> hiveParameters = hiveTable.getParameters();
+        hiveParameters.remove(HiveTableProperties.ARCTIC_TABLE_FLAG);
+        client.alterTable(tableIdentifier.getDatabase(), tableIdentifier.getTableName(), hiveTable);
+        return null;
+      });
+    } catch (TException | InterruptedException e) {
+      LOG.warn("Failed to alter hive table while rolling back create table operation", e);
+    }
     TableMeta meta = getArcticTableMeta(tableIdentifier);
+    try {
+      client.removeTable(meta.getTableIdentifier(), false);
+    } catch (TException e) {
+      throw new IllegalStateException("error when delete table metadata from metastore");
+    }
     ((MixedHiveTables)tables).dropTableMetaButNotDropHiveTable(meta);
   }
 
@@ -227,8 +245,8 @@ public class ArcticHiveCatalog extends BasicArcticCatalog {
 
     @Override
     protected void doRollbackCreateTable(TableMeta meta) {
-      super.doRollbackCreateTable(meta);
       if (allowExistedHiveTable) {
+        ((MixedHiveTables)tables).dropTableMetaButNotDropHiveTable(meta);
         LOG.info("No need to drop hive table");
         com.netease.arctic.ams.api.TableIdentifier tableIdentifier = meta.getTableIdentifier();
         try {
@@ -245,6 +263,7 @@ public class ArcticHiveCatalog extends BasicArcticCatalog {
           LOG.warn("Failed to alter hive table while rolling back create table operation", e);
         }
       } else {
+        super.doRollbackCreateTable(meta);
         try {
           hiveClientPool.run(client -> {
             client.dropTable(

--- a/hive/src/main/java/com/netease/arctic/hive/catalog/MixedHiveTables.java
+++ b/hive/src/main/java/com/netease/arctic/hive/catalog/MixedHiveTables.java
@@ -234,21 +234,36 @@ public class MixedHiveTables extends MixedTables {
     super.dropTableByMeta(tableMeta, purge);
     // drop hive table operation will only delete hive table metadata
     // delete data files operation will use BasicArcticCatalog
-    try {
-      hiveClientPool.run(client -> {
-        client.dropTable(tableMeta.getTableIdentifier().getDatabase(),
-            tableMeta.getTableIdentifier().getTableName(),
-            false /* deleteData */,
-            true /* ignoreUnknownTab */);
-        return null;
-      });
-    } catch (TException | InterruptedException e) {
-      throw new RuntimeException("Failed to drop table:" + tableMeta.getTableIdentifier(), e);
+    if (purge) {
+      try {
+        hiveClientPool.run(client -> {
+          client.dropTable(tableMeta.getTableIdentifier().getDatabase(),
+              tableMeta.getTableIdentifier().getTableName(),
+              false /* deleteData */,
+              true /* ignoreUnknownTab */);
+          return null;
+        });
+      } catch (TException | InterruptedException e) {
+        throw new RuntimeException("Failed to drop table:" + tableMeta.getTableIdentifier(), e);
+      }
+    } else {
+      // if purge is not true, we will not drop the hive table and need to remove the arctic table flag
+      try {
+        hiveClientPool.run(client -> {
+          org.apache.hadoop.hive.metastore.api.Table hiveTable = client.getTable(
+              tableMeta.getTableIdentifier().getDatabase(),
+              tableMeta.getTableIdentifier().getTableName());
+          Map<String, String> hiveParameters = hiveTable.getParameters();
+          hiveParameters.remove(HiveTableProperties.ARCTIC_TABLE_FLAG);
+          client.alterTable(tableMeta.getTableIdentifier().getDatabase(),
+              tableMeta.tableIdentifier.getTableName(), hiveTable);
+          return null;
+        });
+      } catch (TException | InterruptedException e) {
+        throw new RuntimeException("Failed to alter hive table while drop table meta:" +
+            tableMeta.getTableIdentifier(), e);
+      }
     }
-  }
-
-  public void dropTableMetaButNotDropHiveTable(TableMeta tableMeta) {
-    super.dropTableByMeta(tableMeta, false);
   }
 
   protected void fillTableProperties(TableMeta meta) {

--- a/hive/src/main/java/com/netease/arctic/hive/catalog/MixedHiveTables.java
+++ b/hive/src/main/java/com/netease/arctic/hive/catalog/MixedHiveTables.java
@@ -247,6 +247,10 @@ public class MixedHiveTables extends MixedTables {
     }
   }
 
+  public void dropTableMetaButNotDropHiveTable(TableMeta tableMeta) {
+    super.dropTableByMeta(tableMeta, false);
+  }
+
   protected void fillTableProperties(TableMeta meta) {
     super.fillTableProperties(meta);
     String tableLocation = checkLocation(meta, MetaTableProperties.LOCATION_KEY_TABLE);

--- a/hive/src/main/java/com/netease/arctic/hive/utils/UpgradeHiveTableUtil.java
+++ b/hive/src/main/java/com/netease/arctic/hive/utils/UpgradeHiveTableUtil.java
@@ -92,7 +92,7 @@ public class UpgradeHiveTableUtil {
       UpgradeHiveTableUtil.hiveDataMigration((SupportHive) arcticTable, arcticHiveCatalog, tableIdentifier);
     } catch (Throwable t) {
       if (upgradeHive) {
-        arcticHiveCatalog.dropTableButNotDropHiveTable(tableIdentifier);
+        arcticHiveCatalog.dropTable(tableIdentifier, false);
       }
       throw t;
     }

--- a/hive/src/test/java/com/netease/arctic/hive/catalog/TestArcticHiveCatalog.java
+++ b/hive/src/test/java/com/netease/arctic/hive/catalog/TestArcticHiveCatalog.java
@@ -25,6 +25,8 @@ import com.netease.arctic.catalog.TestBasicArcticCatalog;
 import com.netease.arctic.hive.TestHMS;
 import com.netease.arctic.table.TableIdentifier;
 import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.thrift.TException;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -56,6 +58,14 @@ public class TestArcticHiveCatalog extends TestBasicArcticCatalog {
           TableTestHelper.TEST_DB_NAME, TableTestHelper.TEST_TABLE_NAME));
       Assert.assertTrue(TEST_HMS.getHiveClient().getAllTables(TableTestHelper.TEST_DB_NAME)
           .contains(TableTestHelper.TEST_TABLE_NAME));
+    }
+  }
+
+  @After
+  public void cleanUp() throws TException {
+    if (getCatalog() instanceof ArcticHiveCatalog) {
+      TEST_HMS.getHiveClient().dropTable(TableTestHelper.TEST_DB_NAME, TableTestHelper.TEST_TABLE_NAME,
+          true, true);
     }
   }
 }

--- a/hive/src/test/java/com/netease/arctic/hive/catalog/TestArcticHiveCatalog.java
+++ b/hive/src/test/java/com/netease/arctic/hive/catalog/TestArcticHiveCatalog.java
@@ -18,11 +18,16 @@
 
 package com.netease.arctic.hive.catalog;
 
+import com.netease.arctic.TableTestHelper;
 import com.netease.arctic.ams.api.TableFormat;
 import com.netease.arctic.catalog.CatalogTestHelper;
 import com.netease.arctic.catalog.TestBasicArcticCatalog;
 import com.netease.arctic.hive.TestHMS;
+import com.netease.arctic.table.TableIdentifier;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.junit.Assert;
 import org.junit.ClassRule;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -40,5 +45,17 @@ public class TestArcticHiveCatalog extends TestBasicArcticCatalog {
   public static Object[] parameters() {
     return new Object[] {new HiveCatalogTestHelper(TableFormat.MIXED_HIVE, TEST_HMS.getHiveConf()),
                          new HiveCatalogTestHelper(TableFormat.ICEBERG, TEST_HMS.getHiveConf())};
+  }
+
+  @Test
+  public void testDropTableButNotDropHiveTable() throws MetaException {
+    if (getCatalog() instanceof ArcticHiveCatalog) {
+      getCatalog().createDatabase(TableTestHelper.TEST_DB_NAME);
+      createTestTable();
+      ((ArcticHiveCatalog)getCatalog()).dropTableButNotDropHiveTable(TableIdentifier.of(getCatalog().name(),
+          TableTestHelper.TEST_DB_NAME, TableTestHelper.TEST_TABLE_NAME));
+      Assert.assertTrue(TEST_HMS.getHiveClient().getAllTables(TableTestHelper.TEST_DB_NAME)
+          .contains(TableTestHelper.TEST_TABLE_NAME));
+    }
   }
 }

--- a/hive/src/test/java/com/netease/arctic/hive/catalog/TestArcticHiveCatalog.java
+++ b/hive/src/test/java/com/netease/arctic/hive/catalog/TestArcticHiveCatalog.java
@@ -54,8 +54,8 @@ public class TestArcticHiveCatalog extends TestBasicArcticCatalog {
     if (getCatalog() instanceof ArcticHiveCatalog) {
       getCatalog().createDatabase(TableTestHelper.TEST_DB_NAME);
       createTestTable();
-      ((ArcticHiveCatalog)getCatalog()).dropTableButNotDropHiveTable(TableIdentifier.of(getCatalog().name(),
-          TableTestHelper.TEST_DB_NAME, TableTestHelper.TEST_TABLE_NAME));
+      getCatalog().dropTable(TableIdentifier.of(getCatalog().name(),
+          TableTestHelper.TEST_DB_NAME, TableTestHelper.TEST_TABLE_NAME), false);
       Assert.assertTrue(TEST_HMS.getHiveClient().getAllTables(TableTestHelper.TEST_DB_NAME)
           .contains(TableTestHelper.TEST_TABLE_NAME));
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

fix #1807 

## Brief change log
Added a logic that deletes the hive table, but does not delete the amoro table


## How was this patch tested?
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
