### PR TITLE
[AMORO-1817] Remove JDK internal imports

### DIFF
--- a/core/src/main/java/com/netease/arctic/table/TableMetaStore.java
+++ b/core/src/main/java/com/netease/arctic/table/TableMetaStore.java
@@ -35,7 +35,6 @@ import org.apache.iceberg.relocated.com.google.common.hash.Hashing;
 import org.apache.iceberg.relocated.com.google.common.io.ByteStreams;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import sun.security.krb5.KrbException;
 
 import java.io.ByteArrayInputStream;
 import java.io.FileInputStream;
@@ -229,7 +228,7 @@ public class TableMetaStore implements Serializable {
           constructUgi();
         }
         LOG.info("Complete to build ugi {}", authInformation());
-      } catch (IOException | KrbException e) {
+      } catch (IOException e) {
         throw new RuntimeException("Fail to init user group information", e);
       }
     } else {
@@ -326,12 +325,11 @@ public class TableMetaStore implements Serializable {
     return authInformation;
   }
 
-  private void constructUgi() throws IOException, KrbException {
+  private void constructUgi() throws IOException {
     String krbConfFile = saveConfInPath(confCachePath, KRB_CONF_FILE_NAME, krbConf);
     String keyTabFile = saveConfInPath(confCachePath, KEY_TAB_FILE_NAME, krbKeyTab);
     System.clearProperty(HADOOP_USER_PROPERTY);
     System.setProperty(KRB5_CONF_PROPERTY, krbConfFile);
-    sun.security.krb5.Config.refresh();
     UserGroupInformation.setConfiguration(getConfiguration());
     KerberosName.resetDefaultRealm();
     ugi = UserGroupInformation.loginUserFromKeytabAndReturnUGI(krbPrincipal, keyTabFile);


### PR DESCRIPTION
## Why are the changes needed?
Resolve #1817.

## Brief change log

  - *Remove sun.security.krb5.Config.refresh()*
  - *Remove KrbException.*

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
