### PR TITLE
[AMORO-1820]: Fix spark drop namespace error in rest catalog services.

### DIFF
--- a/ams/server/src/main/java/com/netease/arctic/server/IcebergRestCatalogService.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/IcebergRestCatalogService.java
@@ -38,6 +38,7 @@ import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.rest.RESTResponse;
 import org.apache.iceberg.rest.RESTSerializers;
 import org.apache.iceberg.rest.requests.CreateNamespaceRequest;
@@ -121,7 +122,6 @@ public class IcebergRestCatalogService extends PersistentBase {
     };
   }
 
-
   public boolean needHandleException(Context ctx) {
     return ctx.req.getRequestURI().startsWith(ICEBERG_REST_API_PREFIX);
   }
@@ -137,9 +137,10 @@ public class IcebergRestCatalogService extends PersistentBase {
     jsonResponse(ctx, response);
     if (code.code >= 500) {
       LOG.warn("InternalServer Error", e);
+    } else {
+      LOG.debug("Iceberg Rest Catalog Service exception: ", e);
     }
   }
-
 
   /**
    * GET PREFIX/v1/config?warehouse={warehouse}
@@ -167,23 +168,25 @@ public class IcebergRestCatalogService extends PersistentBase {
     jsonResponse(ctx, configResponse);
   }
 
-
   /**
    * GET PREFIX/{catalog}/v1/namespaces
    */
   public void listNamespaces(Context ctx) {
     handleCatalog(ctx, catalog -> {
       String ns = ctx.req.getParameter("parent");
-      checkUnsupported(ns == null,
-          "The catalog doesn't support multi-level namespaces");
-      List<Namespace> nsLists = catalog.listDatabases()
-          .stream().map(Namespace::of)
-          .collect(Collectors.toList());
+      List<Namespace> nsLists = Lists.newArrayList();
+      List<String> databases = catalog.listDatabases();
+      if (ns == null) {
+        nsLists = databases.stream().map(Namespace::of)
+            .collect(Collectors.toList());
+      } else {
+        checkUnsupported(!ns.contains("."), "multi-level namespace is not supported, parent: " + ns);
+        checkDatabaseExist(catalog.exist(ns), ns);
+      }
       return ListNamespacesResponse.builder()
           .addAll(nsLists)
           .build();
     });
-
   }
 
   /**
@@ -193,7 +196,8 @@ public class IcebergRestCatalogService extends PersistentBase {
     handleCatalog(ctx, catalog -> {
       CreateNamespaceRequest request = bodyAsClass(ctx, CreateNamespaceRequest.class);
       Namespace ns = request.namespace();
-      checkUnsupported(ns.length() == 1,
+      checkUnsupported(
+          ns.length() == 1,
           "multi-level namespace is not supported now");
       String database = ns.level(0);
       checkAlreadyExists(!catalog.exist(database), "Database", database);
@@ -229,7 +233,6 @@ public class IcebergRestCatalogService extends PersistentBase {
     InternalCatalog internalCatalog = getCatalog(catalog);
     internalCatalog.dropDatabase(ns);
   }
-
 
   /**
    * POST PREFIX/v1/catalogs/{catalog}/namespaces/{namespace}/properties
@@ -268,7 +271,8 @@ public class IcebergRestCatalogService extends PersistentBase {
       String location = request.location();
       if (StringUtils.isBlank(location)) {
         String warehouse = catalog.getMetadata().getCatalogProperties().get(CatalogMetaProperties.KEY_WAREHOUSE);
-        Preconditions.checkState(StringUtils.isNotBlank(warehouse),
+        Preconditions.checkState(
+            StringUtils.isNotBlank(warehouse),
             "catalog warehouse is not configured");
         warehouse = LocationUtil.stripTrailingSlash(warehouse);
         location = warehouse + "/" + database + "/" + tableName;
@@ -320,7 +324,6 @@ public class IcebergRestCatalogService extends PersistentBase {
       return LoadTableResponse.builder()
           .withTableMetadata(tableMetadata)
           .build();
-
     });
   }
 
@@ -351,7 +354,6 @@ public class IcebergRestCatalogService extends PersistentBase {
     });
   }
 
-
   /**
    * DELETE PREFIX/v1/catalogs/{catalog}/namespaces/{namespace}/tables/{table}
    */
@@ -374,12 +376,10 @@ public class IcebergRestCatalogService extends PersistentBase {
         }
       }
 
-
       ctx.status(HttpCode.NO_CONTENT);
       return null;
     });
   }
-
 
   /**
    * HEAD PREFIX/v1/catalogs/{catalog}/namespaces/{namespace}/tables/{table}
@@ -388,14 +388,12 @@ public class IcebergRestCatalogService extends PersistentBase {
     handleTable(ctx, ((catalog, tableMeta) -> null));
   }
 
-
   /**
    * POST PREFIX/v1/catalogs/{catalog}/tables/rename
    */
   public void renameTable(Context ctx) {
     throw new UnsupportedOperationException("rename is not supported now.");
   }
-
 
   /**
    * POST PREFIX/v1/catalogs/{catalog}/namespaces/{namespace}/tables/{table}/metrics
@@ -420,7 +418,6 @@ public class IcebergRestCatalogService extends PersistentBase {
     });
   }
 
-
   private <T> T bodyAsClass(Context ctx, Class<T> clz) {
     return jsonMapper.fromJsonString(ctx.body(), clz);
   }
@@ -441,7 +438,6 @@ public class IcebergRestCatalogService extends PersistentBase {
     }
   }
 
-
   private void handleNamespace(Context ctx, BiFunction<InternalCatalog, String, ? extends RESTResponse> handler) {
     handleCatalog(ctx, catalog -> {
       String ns = ctx.pathParam("namespace");
@@ -450,7 +446,6 @@ public class IcebergRestCatalogService extends PersistentBase {
       return handler.apply(catalog, ns);
     });
   }
-
 
   private void handleTable(
       Context ctx,
@@ -463,7 +458,8 @@ public class IcebergRestCatalogService extends PersistentBase {
       com.netease.arctic.server.table.TableMetadata metadata = tableService.loadTableMetadata(
           com.netease.arctic.table.TableIdentifier.of(catalog.name(), database, tableName).buildTableIdentifier()
       );
-      Preconditions.checkArgument(metadata.getFormat() == TableFormat.ICEBERG,
+      Preconditions.checkArgument(
+          metadata.getFormat() == TableFormat.ICEBERG,
           "it's not an iceberg table");
       return handler.apply(catalog, metadata);
     });

--- a/ams/server/src/main/java/com/netease/arctic/server/IcebergRestCatalogService.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/IcebergRestCatalogService.java
@@ -138,6 +138,7 @@ public class IcebergRestCatalogService extends PersistentBase {
     if (code.code >= 500) {
       LOG.warn("InternalServer Error", e);
     } else {
+      // those errors happened when the client-side passed arguments with problems.
       LOG.debug("Iceberg Rest Catalog Service exception: ", e);
     }
   }

--- a/ams/server/src/test/java/com/netease/arctic/server/TestIcebergRestCatalogService.java
+++ b/ams/server/src/test/java/com/netease/arctic/server/TestIcebergRestCatalogService.java
@@ -44,14 +44,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-
 public class TestIcebergRestCatalogService {
   private static final Logger LOG = LoggerFactory.getLogger(TestIcebergRestCatalogService.class);
 
-
   static AmsEnvironment ams = AmsEnvironment.getIntegrationInstances();
   static String restCatalogUri = IcebergRestCatalogService.ICEBERG_REST_API_PREFIX;
-
 
   private final String database = "test_ns";
   private final String table = "test_iceberg_tbl";
@@ -85,7 +82,6 @@ public class TestIcebergRestCatalogService {
         "/" + database + "/" + table;
   }
 
-
   @Nested
   public class CatalogPropertiesTest {
     @Test
@@ -116,7 +112,6 @@ public class TestIcebergRestCatalogService {
     }
   }
 
-
   @Nested
   public class NamespaceTests {
     RESTCatalog nsCatalog;
@@ -131,11 +126,11 @@ public class TestIcebergRestCatalogService {
       Assertions.assertTrue(nsCatalog.listNamespaces().isEmpty());
       nsCatalog.createNamespace(Namespace.of(database));
       Assertions.assertEquals(1, nsCatalog.listNamespaces().size());
+      Assertions.assertEquals(0, nsCatalog.listNamespaces(Namespace.of(database)).size());
       nsCatalog.dropNamespace(Namespace.of(database));
       Assertions.assertTrue(nsCatalog.listNamespaces().isEmpty());
     }
   }
-
 
   @Nested
   public class TableTests {
@@ -157,7 +152,6 @@ public class TestIcebergRestCatalogService {
       nsCatalog.dropTable(identifier);
       if (serverCatalog.exist(database, table)) {
         serverCatalog.dropTable(database, table);
-
       }
       serverCatalog.dropDatabase(database);
     }
@@ -225,7 +219,6 @@ public class TestIcebergRestCatalogService {
       Assertions.assertEquals(files.size(), tasks.size());
     }
 
-
     @Test
     public void testArcticCatalogLoader() {
       Table tbl = nsCatalog.createTable(identifier, schema, spec);
@@ -252,9 +245,7 @@ public class TestIcebergRestCatalogService {
           arcticTable, reader, Expressions.alwaysTrue());
       Assertions.assertEquals(newRecords.size(), records.size());
     }
-
   }
-
 
   private RESTCatalog loadCatalog(Map<String, String> clientProperties) {
     clientProperties.put("uri", ams.getHttpUrl() + restCatalogUri);
@@ -268,5 +259,4 @@ public class TestIcebergRestCatalogService {
         clientProperties, store.getConfiguration()
     );
   }
-
 }


### PR DESCRIPTION
 

## Why are the changes needed?

fix #1820 

## Brief change log

- Return empty list when listNamespace passes a database name

## How was this patch tested?
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [X] Run test locally before making a pull request


