### PR TITLE
[AMORO-1822][Bug]: Failed to edit optimizer group

### DIFF
--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/SchedulingPolicy.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/SchedulingPolicy.java
@@ -4,7 +4,6 @@ import com.google.common.collect.Maps;
 import com.netease.arctic.ams.api.resource.ResourceGroup;
 import com.netease.arctic.server.table.ServerTableIdentifier;
 import com.netease.arctic.server.table.TableRuntime;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 
 import java.util.Comparator;
@@ -33,12 +32,12 @@ public class SchedulingPolicy {
   public void setTableSorterIfNeeded(ResourceGroup optimizerGroup) {
     String schedulingPolicy = Optional.ofNullable(optimizerGroup.getProperties())
         .orElseGet(Maps::newHashMap)
-        .get(SCHEDULING_POLICY_PROPERTY_NAME);
-    if ((StringUtils.isBlank(schedulingPolicy) || schedulingPolicy.equalsIgnoreCase(QUOTA)) &&
-        tableSorter == null || (tableSorter instanceof BalancedSorter)) {
+        .getOrDefault(SCHEDULING_POLICY_PROPERTY_NAME, QUOTA);
+    if (schedulingPolicy.equalsIgnoreCase(QUOTA) &&
+        (tableSorter == null || (tableSorter instanceof BalancedSorter))) {
       tableSorter = new QuotaOccupySorter();
     } else if (schedulingPolicy.equalsIgnoreCase(BALANCED) &&
-        tableSorter == null || (tableSorter instanceof QuotaOccupySorter)) {
+        (tableSorter == null || (tableSorter instanceof QuotaOccupySorter))) {
       tableSorter = new BalancedSorter();
     } else {
       throw new IllegalArgumentException("Illegal scheduling policy: " + schedulingPolicy);


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
 
FIX #1822

## Brief change log

When I edited an optimizer group, it will fail if I did not add the scheduling-policy property.

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
