### PR TITLE
[AMORO-1866] Replace binpack task strategy from "fragment file first" with "segment file first".

### DIFF
--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/AbstractPartitionPlan.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/AbstractPartitionPlan.java
@@ -341,20 +341,18 @@ public abstract class AbstractPartitionPlan implements PartitionEvaluator {
     @Override
     public List<SplitTask> splitTasks(int targetTaskCount) {
       // bin-packing
-      List<FileTask> allDataFiles = Lists.newArrayList();
-      segmentFiles.forEach((dataFile, deleteFiles) ->
-          allDataFiles.add(new FileTask(dataFile, deleteFiles, false)));
+      List<FileTask> allDataFiles = Lists.newLinkedList();
       fragmentFiles.forEach((dataFile, deleteFiles) ->
           allDataFiles.add(new FileTask(dataFile, deleteFiles, true)));
+      segmentFiles.forEach((dataFile, deleteFiles) ->
+          allDataFiles.add(new FileTask(dataFile, deleteFiles, false)));
 
-      long taskSize = config.getTargetSize();
-      Long sum = allDataFiles.stream().map(f -> f.getFile().fileSizeInBytes()).reduce(0L, Long::sum);
-      int taskCnt = (int) (sum / taskSize) + 1;
-      List<List<FileTask>> packed = new BinPacking.ListPacker<FileTask>(taskSize, taskCnt, true)
+      List<List<FileTask>> packed = new BinPacking.ListPacker<FileTask>(
+          config.getTargetSize(), Integer.MAX_VALUE, false)
           .pack(allDataFiles, f -> f.getFile().fileSizeInBytes());
 
       // collect
-      List<SplitTask> results = Lists.newArrayList();
+      List<SplitTask> results = Lists.newArrayListWithCapacity(packed.size());
       for (List<FileTask> fileTasks : packed) {
         Map<IcebergDataFile, List<IcebergContentFile<?>>> fragmentFiles = Maps.newHashMap();
         Map<IcebergDataFile, List<IcebergContentFile<?>>> segmentFiles = Maps.newHashMap();

--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/OptimizingPlanner.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/OptimizingPlanner.java
@@ -117,7 +117,6 @@ public class OptimizingPlanner extends OptimizingEvaluator {
 
     List<PartitionEvaluator> evaluators = new ArrayList<>(partitionPlanMap.values());
     evaluators.sort(Comparator.comparing(PartitionEvaluator::getWeight));
-    Collections.reverse(evaluators);
 
     double maxInputSize = MAX_INPUT_FILE_SIZE_PER_THREAD * availableCore;
     List<PartitionEvaluator> inputPartitions = Lists.newArrayList();


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Fix #1866 

## Brief change log

Putting a "fragment file first" binpack strategy will prioritize packing fragment files, and then only try to find the segement file once the fragment file is almost packed, which will try to avoid having only one fragment file in a bin, which can lead to certain tasks being filtered.

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
