### PR TITLE
[AMORO-1883] Perform file filtering when adding files to `PartitionEvaluator` instead of during splitting tasks

### DIFF
--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/AbstractPartitionPlan.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/AbstractPartitionPlan.java
@@ -107,6 +107,8 @@ public abstract class AbstractPartitionPlan implements PartitionEvaluator {
       rewriteDataFiles.put(dataFile, deletes);
     } else if (evaluator().segmentFileShouldRewritePos(dataFile, deletes)) {
       rewritePosDataFiles.put(dataFile, deletes);
+    } else {
+      return false;
     }
     return true;
   }

--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/AbstractPartitionPlan.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/AbstractPartitionPlan.java
@@ -52,7 +52,7 @@ public abstract class AbstractPartitionPlan implements PartitionEvaluator {
 
   protected final Map<IcebergDataFile, List<IcebergContentFile<?>>> rewriteDataFiles = Maps.newHashMap();
   protected final Map<IcebergDataFile, List<IcebergContentFile<?>>> rewritePosDataFiles = Maps.newHashMap();
-  // protected Delete files are Delete files related to Data files not optimized in this plan
+  // protected Delete files are Delete files which are related to Data files not optimized in this plan
   protected final Set<String> protectedDeleteFiles = Sets.newHashSet();
 
   public AbstractPartitionPlan(TableRuntime tableRuntime,
@@ -99,7 +99,7 @@ public abstract class AbstractPartitionPlan implements PartitionEvaluator {
   public boolean addFile(IcebergDataFile dataFile, List<IcebergContentFile<?>> deletes) {
     boolean added = evaluator().addFile(dataFile, deletes);
     if (!added) {
-      // if the Data file is not added, it's Delete files should be not be removed from iceberg
+      // if the Data file is not added, it's Delete files should not be removed from iceberg
       deletes.stream().map(delete -> delete.path().toString()).forEach(protectedDeleteFiles::add);
       return false;
     }

--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/AbstractPartitionPlan.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/AbstractPartitionPlan.java
@@ -26,6 +26,7 @@ import com.netease.arctic.server.optimizing.OptimizingConfig;
 import com.netease.arctic.server.optimizing.OptimizingType;
 import com.netease.arctic.server.table.TableRuntime;
 import com.netease.arctic.table.ArcticTable;
+import com.netease.arctic.utils.TablePropertyUtil;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
@@ -49,6 +50,7 @@ public abstract class AbstractPartitionPlan implements PartitionEvaluator {
   private long fromSequence = INVALID_SEQUENCE;
   private long toSequence = INVALID_SEQUENCE;
   protected final long planTime;
+  protected final Map<String, String> partitionProperties;
 
   protected final Map<IcebergDataFile, List<IcebergContentFile<?>>> rewriteDataFiles = Maps.newHashMap();
   protected final Map<IcebergDataFile, List<IcebergContentFile<?>>> rewritePosDataFiles = Maps.newHashMap();
@@ -62,6 +64,7 @@ public abstract class AbstractPartitionPlan implements PartitionEvaluator {
     this.config = tableRuntime.getOptimizingConfig();
     this.tableRuntime = tableRuntime;
     this.planTime = planTime;
+    this.partitionProperties = TablePropertyUtil.getPartitionProperties(table, partition);
   }
 
   @Override
@@ -77,7 +80,7 @@ public abstract class AbstractPartitionPlan implements PartitionEvaluator {
   }
 
   protected CommonPartitionEvaluator buildEvaluator() {
-    return new CommonPartitionEvaluator(tableRuntime, partition, planTime);
+    return new CommonPartitionEvaluator(tableRuntime, partition, partitionProperties, planTime);
   }
 
   @Override
@@ -111,11 +114,6 @@ public abstract class AbstractPartitionPlan implements PartitionEvaluator {
       return false;
     }
     return true;
-  }
-
-  @Override
-  public void addPartitionProperties(Map<String, String> properties) {
-    evaluator().addPartitionProperties(properties);
   }
 
   public List<TaskDescriptor> splitTasks(int targetTaskCount) {

--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/AbstractPartitionPlan.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/AbstractPartitionPlan.java
@@ -26,7 +26,6 @@ import com.netease.arctic.server.optimizing.OptimizingConfig;
 import com.netease.arctic.server.optimizing.OptimizingType;
 import com.netease.arctic.server.table.TableRuntime;
 import com.netease.arctic.table.ArcticTable;
-import org.apache.iceberg.FileContent;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
@@ -51,12 +50,10 @@ public abstract class AbstractPartitionPlan implements PartitionEvaluator {
   private long toSequence = INVALID_SEQUENCE;
   protected final long planTime;
 
-  protected final Map<IcebergDataFile, List<IcebergContentFile<?>>> fragmentFiles = Maps.newHashMap();
-  protected final Map<IcebergDataFile, List<IcebergContentFile<?>>> segmentFiles = Maps.newHashMap();
-  protected final Map<String, Set<IcebergDataFile>> equalityDeleteFileMap = Maps.newHashMap();
-  protected final Map<String, Set<IcebergDataFile>> posDeleteFileMap = Maps.newHashMap();
-  
-  private List<SplitTask> splitTasks;
+  protected final Map<IcebergDataFile, List<IcebergContentFile<?>>> rewriteDataFiles = Maps.newHashMap();
+  protected final Map<IcebergDataFile, List<IcebergContentFile<?>>> rewritePosDataFiles = Maps.newHashMap();
+  // protected Delete files are Delete files related to Data files not optimized in this plan
+  protected final Set<String> protectedDeleteFiles = Sets.newHashSet();
 
   public AbstractPartitionPlan(TableRuntime tableRuntime,
                                ArcticTable table, String partition, long planTime) {
@@ -99,24 +96,19 @@ public abstract class AbstractPartitionPlan implements PartitionEvaluator {
   }
 
   @Override
-  public void addFile(IcebergDataFile dataFile, List<IcebergContentFile<?>> deletes) {
-    evaluator().addFile(dataFile, deletes);
-    if (evaluator().isFragmentFile(dataFile)) {
-      fragmentFiles.put(dataFile, deletes);
-    } else {
-      segmentFiles.put(dataFile, deletes);
+  public boolean addFile(IcebergDataFile dataFile, List<IcebergContentFile<?>> deletes) {
+    boolean added = evaluator().addFile(dataFile, deletes);
+    if (!added) {
+      // if the Data file is not added, it's Delete files should be not be removed from iceberg
+      deletes.stream().map(delete -> delete.path().toString()).forEach(protectedDeleteFiles::add);
+      return false;
     }
-    for (IcebergContentFile<?> deleteFile : deletes) {
-      if (deleteFile.content() == FileContent.POSITION_DELETES) {
-        posDeleteFileMap
-            .computeIfAbsent(deleteFile.path().toString(), delete -> Sets.newHashSet())
-            .add(dataFile);
-      } else {
-        equalityDeleteFileMap
-            .computeIfAbsent(deleteFile.path().toString(), delete -> Sets.newHashSet())
-            .add(dataFile);
-      }
+    if (evaluator().fileShouldRewrite(dataFile, deletes)) {
+      rewriteDataFiles.put(dataFile, deletes);
+    } else if (evaluator().segmentFileShouldRewritePos(dataFile, deletes)) {
+      rewritePosDataFiles.put(dataFile, deletes);
     }
+    return true;
   }
 
   @Override
@@ -128,34 +120,18 @@ public abstract class AbstractPartitionPlan implements PartitionEvaluator {
     if (taskSplitter == null) {
       taskSplitter = buildTaskSplitter();
     }
-    this.splitTasks = taskSplitter.splitTasks(targetTaskCount).stream()
-        .filter(this::taskNeedExecute).collect(Collectors.toList());
-    return this.splitTasks.stream()
+    beforeSplit();
+    return taskSplitter.splitTasks(targetTaskCount).stream()
         .map(task -> task.buildTask(buildTaskProperties()))
         .collect(Collectors.toList());
   }
-
-  protected boolean taskNeedExecute(SplitTask task) {
-    // if there are no delete files and no more than 1 rewrite files, we should not execute
-    return !task.getDeleteFiles().isEmpty() || task.getRewriteDataFiles().size() > 1;
-  }
-
-  private boolean isOptimizing(IcebergDataFile dataFile) {
-    return this.splitTasks.stream().anyMatch(task -> task.contains(dataFile));
+  
+  protected void beforeSplit() {
   }
 
   protected abstract TaskSplitter buildTaskSplitter();
 
   protected abstract OptimizingInputProperties buildTaskProperties();
-
-  protected boolean fileShouldFullOptimizing(IcebergDataFile dataFile, List<IcebergContentFile<?>> deleteFiles) {
-    if (config.isFullRewriteAllFiles()) {
-      return true;
-    } else {
-      // if a file is related any delete files or is not big enough, it should full optimizing
-      return !deleteFiles.isEmpty() || dataFile.fileSizeInBytes() < config.getTargetSize() * 0.9;
-    }
-  }
 
   protected void markSequence(long sequence) {
     if (fromSequence == INVALID_SEQUENCE || fromSequence > sequence) {
@@ -225,39 +201,15 @@ public abstract class AbstractPartitionPlan implements PartitionEvaluator {
 
   protected class SplitTask {
     private final Set<IcebergDataFile> rewriteDataFiles = Sets.newHashSet();
-    private final Set<IcebergContentFile<?>> deleteFiles = Sets.newHashSet();
     private final Set<IcebergDataFile> rewritePosDataFiles = Sets.newHashSet();
+    private final Set<IcebergContentFile<?>> deleteFiles = Sets.newHashSet();
 
-    public SplitTask(Map<IcebergDataFile, List<IcebergContentFile<?>>> fragmentFiles,
-                     Map<IcebergDataFile, List<IcebergContentFile<?>>> segmentFiles) {
-      if (evaluator().isFullNecessary()) {
-        fragmentFiles.forEach((icebergFile, deleteFileSet) -> {
-          if (fileShouldFullOptimizing(icebergFile, deleteFileSet)) {
-            rewriteDataFiles.add(icebergFile);
-            deleteFiles.addAll(deleteFileSet);
-          }
-        });
-        segmentFiles.forEach((icebergFile, deleteFileSet) -> {
-          if (fileShouldFullOptimizing(icebergFile, deleteFileSet)) {
-            rewriteDataFiles.add(icebergFile);
-            deleteFiles.addAll(deleteFileSet);
-          }
-        });
-      } else {
-        fragmentFiles.forEach((icebergFile, deleteFileSet) -> {
-          rewriteDataFiles.add(icebergFile);
-          deleteFiles.addAll(deleteFileSet);
-        });
-        segmentFiles.forEach((icebergFile, deleteFileSet) -> {
-          if (evaluator().shouldRewriteSegmentFile(icebergFile, deleteFileSet)) {
-            rewriteDataFiles.add(icebergFile);
-            deleteFiles.addAll(deleteFileSet);
-          } else if (evaluator.shouldRewritePosForSegmentFile(icebergFile, deleteFileSet)) {
-            rewritePosDataFiles.add(icebergFile);
-            deleteFiles.addAll(deleteFileSet);
-          }
-        });
-      }
+    public SplitTask(Set<IcebergDataFile> rewriteDataFiles,
+                     Set<IcebergDataFile> rewritePosDataFiles,
+                     Set<IcebergContentFile<?>> deleteFiles) {
+      this.rewriteDataFiles.addAll(rewriteDataFiles);
+      this.rewritePosDataFiles.addAll(rewritePosDataFiles);
+      this.deleteFiles.addAll(deleteFiles);
     }
 
     public Set<IcebergDataFile> getRewriteDataFiles() {
@@ -272,23 +224,11 @@ public abstract class AbstractPartitionPlan implements PartitionEvaluator {
       return rewritePosDataFiles;
     }
 
-    public boolean contains(IcebergDataFile dataFile) {
-      return rewriteDataFiles.contains(dataFile) || rewritePosDataFiles.contains(dataFile);
-    }
-
     public TaskDescriptor buildTask(OptimizingInputProperties properties) {
       Set<IcebergContentFile<?>> readOnlyDeleteFiles = Sets.newHashSet();
       Set<IcebergContentFile<?>> rewriteDeleteFiles = Sets.newHashSet();
       for (IcebergContentFile<?> deleteFile : deleteFiles) {
-        Set<IcebergDataFile> relatedDataFiles;
-        if (deleteFile.content() == FileContent.POSITION_DELETES) {
-          relatedDataFiles = posDeleteFileMap.get(deleteFile.path().toString());
-        } else {
-          relatedDataFiles = equalityDeleteFileMap.get(deleteFile.path().toString());
-        }
-        boolean findDataFileNotOptimizing =
-            relatedDataFiles.stream().anyMatch(file -> !contains(file) && !isOptimizing(file));
-        if (findDataFileNotOptimizing) {
+        if (protectedDeleteFiles.contains(deleteFile.path().toString())) {
           readOnlyDeleteFiles.add(deleteFile);
         } else {
           rewriteDeleteFiles.add(deleteFile);
@@ -311,12 +251,12 @@ public abstract class AbstractPartitionPlan implements PartitionEvaluator {
   protected static class FileTask {
     private final IcebergDataFile file;
     private final List<IcebergContentFile<?>> deleteFiles;
-    private final boolean isFragment;
+    private final boolean isRewriteDataFile;
 
-    public FileTask(IcebergDataFile file, List<IcebergContentFile<?>> deleteFiles, boolean isFragment) {
+    public FileTask(IcebergDataFile file, List<IcebergContentFile<?>> deleteFiles, boolean isRewriteDataFile) {
       this.file = file;
       this.deleteFiles = deleteFiles;
-      this.isFragment = isFragment;
+      this.isRewriteDataFile = isRewriteDataFile;
     }
 
     public IcebergDataFile getFile() {
@@ -327,12 +267,12 @@ public abstract class AbstractPartitionPlan implements PartitionEvaluator {
       return deleteFiles;
     }
 
-    public boolean isFragment() {
-      return isFragment;
+    public boolean isRewriteDataFile() {
+      return isRewriteDataFile;
     }
 
-    public boolean isSegment() {
-      return !isFragment;
+    public boolean isRewritePosDataFile() {
+      return !isRewriteDataFile;
     }
   }
 
@@ -342,10 +282,10 @@ public abstract class AbstractPartitionPlan implements PartitionEvaluator {
     public List<SplitTask> splitTasks(int targetTaskCount) {
       // bin-packing
       List<FileTask> allDataFiles = Lists.newArrayList();
-      segmentFiles.forEach((dataFile, deleteFiles) ->
-          allDataFiles.add(new FileTask(dataFile, deleteFiles, false)));
-      fragmentFiles.forEach((dataFile, deleteFiles) ->
+      rewriteDataFiles.forEach((dataFile, deleteFiles) ->
           allDataFiles.add(new FileTask(dataFile, deleteFiles, true)));
+      rewritePosDataFiles.forEach((dataFile, deleteFiles) ->
+          allDataFiles.add(new FileTask(dataFile, deleteFiles, false)));
 
       long taskSize = config.getTargetSize();
       Long sum = allDataFiles.stream().map(f -> f.getFile().fileSizeInBytes()).reduce(0L, Long::sum);
@@ -356,13 +296,19 @@ public abstract class AbstractPartitionPlan implements PartitionEvaluator {
       // collect
       List<SplitTask> results = Lists.newArrayList();
       for (List<FileTask> fileTasks : packed) {
-        Map<IcebergDataFile, List<IcebergContentFile<?>>> fragmentFiles = Maps.newHashMap();
-        Map<IcebergDataFile, List<IcebergContentFile<?>>> segmentFiles = Maps.newHashMap();
-        fileTasks.stream().filter(FileTask::isFragment)
-            .forEach(f -> fragmentFiles.put(f.getFile(), f.getDeleteFiles()));
-        fileTasks.stream().filter(FileTask::isSegment)
-            .forEach(f -> segmentFiles.put(f.getFile(), f.getDeleteFiles()));
-        results.add(new SplitTask(fragmentFiles, segmentFiles));
+        Set<IcebergDataFile> rewriteDataFiles = Sets.newHashSet();
+        Set<IcebergDataFile> rewritePosDataFiles = Sets.newHashSet();
+        Set<IcebergContentFile<?>> deleteFiles = Sets.newHashSet();
+
+        fileTasks.stream().filter(FileTask::isRewriteDataFile).forEach(f -> {
+          rewriteDataFiles.add(f.getFile());
+          deleteFiles.addAll(f.getDeleteFiles());
+        });
+        fileTasks.stream().filter(FileTask::isRewritePosDataFile).forEach(f -> {
+          rewritePosDataFiles.add(f.getFile());
+          deleteFiles.addAll(f.getDeleteFiles());
+        });
+        results.add(new SplitTask(rewriteDataFiles, rewritePosDataFiles, deleteFiles));
       }
       return results;
     }

--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/AbstractPartitionPlan.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/AbstractPartitionPlan.java
@@ -52,8 +52,8 @@ public abstract class AbstractPartitionPlan implements PartitionEvaluator {
 
   protected final Map<IcebergDataFile, List<IcebergContentFile<?>>> rewriteDataFiles = Maps.newHashMap();
   protected final Map<IcebergDataFile, List<IcebergContentFile<?>>> rewritePosDataFiles = Maps.newHashMap();
-  // protected Delete files are Delete files which are related to Data files not optimized in this plan
-  protected final Set<String> protectedDeleteFiles = Sets.newHashSet();
+  // reserved Delete files are Delete files which are related to Data files not optimized in this plan
+  protected final Set<String> reservedDeleteFiles = Sets.newHashSet();
 
   public AbstractPartitionPlan(TableRuntime tableRuntime,
                                ArcticTable table, String partition, long planTime) {
@@ -100,7 +100,7 @@ public abstract class AbstractPartitionPlan implements PartitionEvaluator {
     boolean added = evaluator().addFile(dataFile, deletes);
     if (!added) {
       // if the Data file is not added, it's Delete files should not be removed from iceberg
-      deletes.stream().map(delete -> delete.path().toString()).forEach(protectedDeleteFiles::add);
+      deletes.stream().map(delete -> delete.path().toString()).forEach(reservedDeleteFiles::add);
       return false;
     }
     if (evaluator().fileShouldRewrite(dataFile, deletes)) {
@@ -228,7 +228,7 @@ public abstract class AbstractPartitionPlan implements PartitionEvaluator {
       Set<IcebergContentFile<?>> readOnlyDeleteFiles = Sets.newHashSet();
       Set<IcebergContentFile<?>> rewriteDeleteFiles = Sets.newHashSet();
       for (IcebergContentFile<?> deleteFile : deleteFiles) {
-        if (protectedDeleteFiles.contains(deleteFile.path().toString())) {
+        if (reservedDeleteFiles.contains(deleteFile.path().toString())) {
           readOnlyDeleteFiles.add(deleteFile);
         } else {
           rewriteDeleteFiles.add(deleteFile);

--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/CommonPartitionEvaluator.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/CommonPartitionEvaluator.java
@@ -43,6 +43,7 @@ public class CommonPartitionEvaluator implements PartitionEvaluator {
   protected final OptimizingConfig config;
   protected final long fragmentSize;
   protected final long planTime;
+  protected final Map<String, String> partitionProperties;
   private final boolean reachFullInterval;
 
   // fragment files
@@ -68,7 +69,8 @@ public class CommonPartitionEvaluator implements PartitionEvaluator {
   private OptimizingType optimizingType = null;
   private String name;
 
-  public CommonPartitionEvaluator(TableRuntime tableRuntime, String partition, long planTime) {
+  public CommonPartitionEvaluator(TableRuntime tableRuntime, String partition, Map<String, String> partitionProperties,
+                                  long planTime) {
     this.partition = partition;
     this.tableRuntime = tableRuntime;
     this.config = tableRuntime.getOptimizingConfig();
@@ -76,6 +78,7 @@ public class CommonPartitionEvaluator implements PartitionEvaluator {
     this.planTime = planTime;
     this.reachFullInterval = config.getFullTriggerInterval() >= 0 &&
         planTime - tableRuntime.getLastFullOptimizingTime() > config.getFullTriggerInterval();
+    this.partitionProperties = partitionProperties;
   }
 
   @Override
@@ -94,10 +97,6 @@ public class CommonPartitionEvaluator implements PartitionEvaluator {
     } else {
       return addSegmentFile(dataFile, deletes);
     }
-  }
-
-  @Override
-  public void addPartitionProperties(Map<String, String> properties) {
   }
 
   private boolean isDuplicateDelete(IcebergContentFile<?> delete) {

--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/CommonPartitionEvaluator.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/CommonPartitionEvaluator.java
@@ -43,6 +43,7 @@ public class CommonPartitionEvaluator implements PartitionEvaluator {
   protected final OptimizingConfig config;
   protected final long fragmentSize;
   protected final long planTime;
+  private final boolean reachFullInterval;
 
   // fragment files
   protected int fragmentFileCount = 0;
@@ -66,7 +67,6 @@ public class CommonPartitionEvaluator implements PartitionEvaluator {
   private Boolean necessary = null;
   private OptimizingType optimizingType = null;
   private String name;
-  private Boolean reachFullInterval = null;
 
   public CommonPartitionEvaluator(TableRuntime tableRuntime, String partition, long planTime) {
     this.partition = partition;
@@ -74,6 +74,8 @@ public class CommonPartitionEvaluator implements PartitionEvaluator {
     this.config = tableRuntime.getOptimizingConfig();
     this.fragmentSize = config.getTargetSize() / config.getFragmentRatio();
     this.planTime = planTime;
+    this.reachFullInterval = config.getFullTriggerInterval() >= 0 &&
+        planTime - tableRuntime.getLastFullOptimizingTime() > config.getFullTriggerInterval();
   }
 
   @Override
@@ -248,10 +250,6 @@ public class CommonPartitionEvaluator implements PartitionEvaluator {
   }
 
   protected boolean reachFullInterval() {
-    if (reachFullInterval == null) {
-      reachFullInterval = config.getFullTriggerInterval() >= 0 &&
-          planTime - tableRuntime.getLastFullOptimizingTime() > config.getFullTriggerInterval();
-    }
     return reachFullInterval;
   }
 

--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/CommonPartitionEvaluator.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/CommonPartitionEvaluator.java
@@ -92,6 +92,9 @@ public class CommonPartitionEvaluator implements PartitionEvaluator {
 
   @Override
   public boolean addFile(IcebergDataFile dataFile, List<IcebergContentFile<?>> deletes) {
+    if (!config.isEnabled()) {
+      return false;
+    }
     if (isFragmentFile(dataFile)) {
       return addFragmentFile(dataFile, deletes);
     } else {

--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/MixedHivePartitionPlan.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/MixedHivePartitionPlan.java
@@ -59,7 +59,7 @@ public class MixedHivePartitionPlan extends MixedIcebergPartitionPlan {
   protected void beforeSplit() {
     super.beforeSplit();
     if (evaluator().isFullOptimizing() && moveFiles2CurrentHiveLocation()) {
-      // This is an improvement for full optimizing of hive table, if there is no delete files, we only have to move 
+      // This is an improvement for full optimizing of hive table, if there are no delete files, we only have to move 
       // files not in hive location to hive location, so the files in the hive location should not be optimizing.
       Preconditions.checkArgument(protectedDeleteFiles.isEmpty(), "delete files should be empty");
       rewriteDataFiles.entrySet().removeIf(entry -> evaluator().inHiveLocation(entry.getKey()));

--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/MixedHivePartitionPlan.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/MixedHivePartitionPlan.java
@@ -108,6 +108,8 @@ public class MixedHivePartitionPlan extends MixedIcebergPartitionPlan {
     private boolean filesNotInHiveLocation = false;
     // partition property
     protected long lastHiveOptimizedTime;
+    
+    private Boolean reachHiveRefreshInterval;
 
     public MixedHivePartitionEvaluator(TableRuntime tableRuntime, String partition, String hiveLocation,
                                        long planTime, boolean keyedTable) {
@@ -168,7 +170,11 @@ public class MixedHivePartitionPlan extends MixedIcebergPartitionPlan {
     }
 
     protected boolean reachHiveRefreshInterval() {
-      return config.getHiveRefreshInterval() >= 0 && planTime - lastHiveOptimizedTime > config.getHiveRefreshInterval();
+      if (reachHiveRefreshInterval == null) {
+        reachHiveRefreshInterval =
+            config.getHiveRefreshInterval() >= 0 && planTime - lastHiveOptimizedTime > config.getHiveRefreshInterval();
+      }
+      return reachHiveRefreshInterval;
     }
 
     @Override

--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/MixedHivePartitionPlan.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/MixedHivePartitionPlan.java
@@ -61,7 +61,7 @@ public class MixedHivePartitionPlan extends MixedIcebergPartitionPlan {
     if (evaluator().isFullOptimizing() && moveFiles2CurrentHiveLocation()) {
       // This is an improvement for full optimizing of hive table, if there are no delete files, we only have to move 
       // files not in hive location to hive location, so the files in the hive location should not be optimizing.
-      Preconditions.checkArgument(protectedDeleteFiles.isEmpty(), "delete files should be empty");
+      Preconditions.checkArgument(reservedDeleteFiles.isEmpty(), "delete files should be empty");
       rewriteDataFiles.entrySet().removeIf(entry -> evaluator().inHiveLocation(entry.getKey()));
       rewritePosDataFiles.entrySet().removeIf(entry -> evaluator().inHiveLocation(entry.getKey()));
     }

--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/MixedHivePartitionPlan.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/MixedHivePartitionPlan.java
@@ -154,15 +154,15 @@ public class MixedHivePartitionPlan extends MixedIcebergPartitionPlan {
 
     @Override
     public boolean isFullNecessary() {
-      if (!reachFullInterval()) {
+      if (!reachFullInterval() && !reachHiveRefreshInterval()) {
         return false;
       }
       return fragmentFileCount > getBaseSplitCount() || hasNewHiveData();
     }
 
     @Override
-    protected boolean reachFullInterval() {
-      return super.reachFullInterval() || reachHiveRefreshInterval();
+    protected boolean isFullOptimizing() {
+      return reachFullInterval() || reachHiveRefreshInterval();
     }
 
     protected boolean hasNewHiveData() {

--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/MixedHivePartitionPlan.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/MixedHivePartitionPlan.java
@@ -130,6 +130,8 @@ public class MixedHivePartitionPlan extends MixedIcebergPartitionPlan {
 
     @Override
     public void addPartitionProperties(Map<String, String> properties) {
+      Preconditions.checkArgument(reachHiveRefreshInterval == null,
+          "partition properties should be added before add files");
       super.addPartitionProperties(properties);
       String optimizedTime = properties.get(HiveTableProperties.PARTITION_PROPERTIES_KEY_TRANSIENT_TIME);
       if (optimizedTime != null) {

--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/MixedIcebergPartitionPlan.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/MixedIcebergPartitionPlan.java
@@ -31,10 +31,12 @@ import com.netease.arctic.table.TableProperties;
 import org.apache.iceberg.FileContent;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 
 import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Predicate;
 
 public class MixedIcebergPartitionPlan extends AbstractPartitionPlan {
@@ -45,8 +47,10 @@ public class MixedIcebergPartitionPlan extends AbstractPartitionPlan {
   }
 
   @Override
-  public void addFile(IcebergDataFile dataFile, List<IcebergContentFile<?>> deletes) {
-    super.addFile(dataFile, deletes);
+  public boolean addFile(IcebergDataFile dataFile, List<IcebergContentFile<?>> deletes) {
+    if (!super.addFile(dataFile, deletes)) {
+      return false;
+    }
     if (evaluator().isChangeFile(dataFile)) {
       markSequence(dataFile.dataSequenceNumber());
     }
@@ -55,20 +59,12 @@ public class MixedIcebergPartitionPlan extends AbstractPartitionPlan {
         markSequence(deleteFile.dataSequenceNumber());
       }
     }
+    return true;
   }
 
   @Override
   protected MixedIcebergPartitionEvaluator evaluator() {
     return ((MixedIcebergPartitionEvaluator) super.evaluator());
-  }
-
-  @Override
-  protected boolean taskNeedExecute(SplitTask task) {
-    if (super.taskNeedExecute(task)) {
-      return true;
-    } else {
-      return task.getRewriteDataFiles().stream().anyMatch(evaluator()::isChangeFile);
-    }
   }
 
   @Override
@@ -109,11 +105,14 @@ public class MixedIcebergPartitionPlan extends AbstractPartitionPlan {
     }
 
     @Override
-    public void addFile(IcebergDataFile dataFile, List<IcebergContentFile<?>> deletes) {
-      super.addFile(dataFile, deletes);
+    public boolean addFile(IcebergDataFile dataFile, List<IcebergContentFile<?>> deletes) {
+      if (!super.addFile(dataFile, deletes)) {
+        return false;
+      }
       if (!hasChangeFiles && isChangeFile(dataFile)) {
         hasChangeFiles = true;
       }
+      return true;
     }
 
     @Override
@@ -166,7 +165,7 @@ public class MixedIcebergPartitionPlan extends AbstractPartitionPlan {
     }
 
     @Override
-    public boolean shouldRewritePosForSegmentFile(IcebergDataFile dataFile, List<IcebergContentFile<?>> deletes) {
+    public boolean segmentFileShouldRewritePos(IcebergDataFile dataFile, List<IcebergContentFile<?>> deletes) {
       if (deletes.stream().anyMatch(
           delete -> delete.content() == FileContent.EQUALITY_DELETES || delete.content() == FileContent.DATA)) {
         // change equality delete file's content is DATA
@@ -232,17 +231,20 @@ public class MixedIcebergPartitionPlan extends AbstractPartitionPlan {
     public List<SplitTask> splitTasks(int targetTaskCount) {
       List<SplitTask> result = Lists.newArrayList();
       FileTree rootTree = FileTree.newTreeRoot();
-      segmentFiles.forEach(rootTree::addSegmentFile);
-      fragmentFiles.forEach(rootTree::addFragmentFile);
+      rewritePosDataFiles.forEach(rootTree::addRewritePosDataFile);
+      rewriteDataFiles.forEach(rootTree::addRewriteDataFile);
       rootTree.completeTree();
       List<FileTree> subTrees = Lists.newArrayList();
       rootTree.splitFileTree(subTrees, new SplitIfNoFileExists());
       for (FileTree subTree : subTrees) {
-        Map<IcebergDataFile, List<IcebergContentFile<?>>> fragmentFiles = Maps.newHashMap();
-        Map<IcebergDataFile, List<IcebergContentFile<?>>> segmentFiles = Maps.newHashMap();
-        subTree.collectFragmentFiles(fragmentFiles);
-        subTree.collectSegmentFiles(segmentFiles);
-        result.add(new SplitTask(fragmentFiles, segmentFiles));
+        Map<IcebergDataFile, List<IcebergContentFile<?>>> rewriteDataFiles = Maps.newHashMap();
+        Map<IcebergDataFile, List<IcebergContentFile<?>>> rewritePosDataFiles = Maps.newHashMap();
+        Set<IcebergContentFile<?>> deleteFiles = Sets.newHashSet();
+        subTree.collectRewriteDataFiles(rewriteDataFiles);
+        subTree.collectRewritePosDataFiles(rewritePosDataFiles);
+        rewriteDataFiles.forEach((f, deletes) -> deleteFiles.addAll(deletes));
+        rewritePosDataFiles.forEach((f, deletes) -> deleteFiles.addAll(deletes));
+        result.add(new SplitTask(rewriteDataFiles.keySet(), rewritePosDataFiles.keySet(), deleteFiles));
       }
       return result;
     }
@@ -251,8 +253,8 @@ public class MixedIcebergPartitionPlan extends AbstractPartitionPlan {
   private static class FileTree {
 
     private final DataTreeNode node;
-    private final Map<IcebergDataFile, List<IcebergContentFile<?>>> fragmentFiles = Maps.newHashMap();
-    private final Map<IcebergDataFile, List<IcebergContentFile<?>>> segmentFiles = Maps.newHashMap();
+    private final Map<IcebergDataFile, List<IcebergContentFile<?>>> rewriteDataFiles = Maps.newHashMap();
+    private final Map<IcebergDataFile, List<IcebergContentFile<?>>> rewritePosDataFiles = Maps.newHashMap();
 
     private FileTree left;
     private FileTree right;
@@ -303,40 +305,40 @@ public class MixedIcebergPartitionPlan extends AbstractPartitionPlan {
       }
     }
 
-    public void collectFragmentFiles(Map<IcebergDataFile, List<IcebergContentFile<?>>> collector) {
-      collector.putAll(fragmentFiles);
+    public void collectRewriteDataFiles(Map<IcebergDataFile, List<IcebergContentFile<?>>> collector) {
+      collector.putAll(rewriteDataFiles);
       if (left != null) {
-        left.collectFragmentFiles(collector);
+        left.collectRewriteDataFiles(collector);
       }
       if (right != null) {
-        right.collectFragmentFiles(collector);
+        right.collectRewriteDataFiles(collector);
       }
     }
 
-    public void collectSegmentFiles(Map<IcebergDataFile, List<IcebergContentFile<?>>> collector) {
-      collector.putAll(segmentFiles);
+    public void collectRewritePosDataFiles(Map<IcebergDataFile, List<IcebergContentFile<?>>> collector) {
+      collector.putAll(rewritePosDataFiles);
       if (left != null) {
-        left.collectSegmentFiles(collector);
+        left.collectRewritePosDataFiles(collector);
       }
       if (right != null) {
-        right.collectSegmentFiles(collector);
+        right.collectRewritePosDataFiles(collector);
       }
     }
 
-    public void addSegmentFile(IcebergDataFile file, List<IcebergContentFile<?>> deleteFiles) {
+    public void addRewritePosDataFile(IcebergDataFile file, List<IcebergContentFile<?>> deleteFiles) {
       PrimaryKeyedFile primaryKeyedFile = (PrimaryKeyedFile) file.internalFile();
       FileTree node = putNodeIfAbsent(primaryKeyedFile.node());
-      node.segmentFiles.put(file, deleteFiles);
+      node.rewritePosDataFiles.put(file, deleteFiles);
     }
 
-    public void addFragmentFile(IcebergDataFile file, List<IcebergContentFile<?>> deleteFiles) {
+    public void addRewriteDataFile(IcebergDataFile file, List<IcebergContentFile<?>> deleteFiles) {
       PrimaryKeyedFile primaryKeyedFile = (PrimaryKeyedFile) file.internalFile();
       FileTree node = putNodeIfAbsent(primaryKeyedFile.node());
-      node.fragmentFiles.put(file, deleteFiles);
+      node.rewriteDataFiles.put(file, deleteFiles);
     }
 
     public boolean isRootEmpty() {
-      return segmentFiles.isEmpty() && fragmentFiles.isEmpty();
+      return rewritePosDataFiles.isEmpty() && rewriteDataFiles.isEmpty();
     }
 
     public boolean isLeaf() {
@@ -380,7 +382,7 @@ public class MixedIcebergPartitionPlan extends AbstractPartitionPlan {
     }
 
     private boolean fileExist() {
-      return !segmentFiles.isEmpty() || !fragmentFiles.isEmpty();
+      return !rewritePosDataFiles.isEmpty() || !rewriteDataFiles.isEmpty();
     }
   }
 

--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/PartitionEvaluator.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/PartitionEvaluator.java
@@ -25,6 +25,9 @@ import com.netease.arctic.server.optimizing.OptimizingType;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * PartitionEvaluator is used to evaluate whether a partition is necessary to be optimized.
+ */
 public interface PartitionEvaluator {
 
   /**
@@ -34,40 +37,95 @@ public interface PartitionEvaluator {
 
   }
 
+  /**
+   * Get the partition name.
+   *
+   * @return the partition name
+   */
   String getPartition();
 
   /**
    * Add a Data file and its related Delete files to this evaluator
+   *
    * @param dataFile - Data file
    * @param deletes  - Delete files
    * @return true if the file is added successfully, false if the file will not be optimized
    */
   boolean addFile(IcebergDataFile dataFile, List<IcebergContentFile<?>> deletes);
-  
+
+  /**
+   * Add some properties of this partition. It should be noted that properties should be added before adding any files.
+   *
+   * @param properties - properties of this partition
+   */
   void addPartitionProperties(Map<String, String> properties);
 
+  /**
+   * Whether this partition is necessary to optimize.
+   *
+   * @return true for is necessary to optimize, false for not necessary
+   */
   boolean isNecessary();
 
+  /**
+   * Get the cost of optimizing for this partition.
+   *
+   * @return the cost of optimizing
+   */
   long getCost();
-  
+
+  /**
+   * Get the weight of this partition which determines the priority of partition execution.
+   *
+   * @return the weight of this partition
+   */
   Weight getWeight();
 
+  /**
+   * Get the optimizing type of this partition.
+   *
+   * @return the OptimizingType
+   */
   OptimizingType getOptimizingType();
 
+  /**
+   * Get the count of fragment files involved in optimizing.
+   */
   int getFragmentFileCount();
 
+  /**
+   * Get the total size of fragment files involved in optimizing.
+   */
   long getFragmentFileSize();
 
+  /**
+   * Get the count of segment files involved in optimizing.
+   */
   int getSegmentFileCount();
 
+  /**
+   * Get the total size of segment files involved in optimizing.
+   */
   long getSegmentFileSize();
 
+  /**
+   * Get the count of equality delete files involved in optimizing.
+   */
   int getEqualityDeleteFileCount();
 
+  /**
+   * Get the total size of equality delete files involved in optimizing.
+   */
   long getEqualityDeleteFileSize();
 
+  /**
+   * Get the count of positional delete files involved in optimizing.
+   */
   int getPosDeleteFileCount();
 
+  /**
+   * Get the total size of positional delete files involved in optimizing.
+   */
   long getPosDeleteFileSize();
 
 }

--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/PartitionEvaluator.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/PartitionEvaluator.java
@@ -36,6 +36,12 @@ public interface PartitionEvaluator {
 
   String getPartition();
 
+  /**
+   * Add a Data file and its related Delete files to this evaluator
+   * @param dataFile - Data file
+   * @param deletes  - Delete files
+   * @return true if the file is added successfully, false if the file will not be optimized
+   */
   boolean addFile(IcebergDataFile dataFile, List<IcebergContentFile<?>> deletes);
   
   void addPartitionProperties(Map<String, String> properties);

--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/PartitionEvaluator.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/PartitionEvaluator.java
@@ -36,7 +36,7 @@ public interface PartitionEvaluator {
 
   String getPartition();
 
-  void addFile(IcebergDataFile dataFile, List<IcebergContentFile<?>> deletes);
+  boolean addFile(IcebergDataFile dataFile, List<IcebergContentFile<?>> deletes);
   
   void addPartitionProperties(Map<String, String> properties);
 

--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/PartitionEvaluator.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/PartitionEvaluator.java
@@ -23,7 +23,6 @@ import com.netease.arctic.data.IcebergDataFile;
 import com.netease.arctic.server.optimizing.OptimizingType;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * PartitionEvaluator is used to evaluate whether a partition is necessary to be optimized.
@@ -52,13 +51,6 @@ public interface PartitionEvaluator {
    * @return true if the file is added successfully, false if the file will not be optimized
    */
   boolean addFile(IcebergDataFile dataFile, List<IcebergContentFile<?>> deletes);
-
-  /**
-   * Add some properties of this partition. It should be noted that properties should be added before adding any files.
-   *
-   * @param properties - properties of this partition
-   */
-  void addPartitionProperties(Map<String, String> properties);
 
   /**
    * Whether this partition is necessary to optimize.

--- a/ams/server/src/test/java/com/netease/arctic/server/optimizing/plan/MixedTablePlanTestBase.java
+++ b/ams/server/src/test/java/com/netease/arctic/server/optimizing/plan/MixedTablePlanTestBase.java
@@ -41,7 +41,6 @@ import com.netease.arctic.table.UnkeyedTable;
 import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
-import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.data.Record;
@@ -286,13 +285,6 @@ public abstract class MixedTablePlanTestBase extends TableTestBase {
   protected AbstractPartitionPlan buildPlanWithCurrentFiles() {
     TableFileScanHelper tableFileScanHelper = getTableFileScanHelper();
     AbstractPartitionPlan partitionPlan = getAndCheckPartitionPlan();
-    PartitionSpec spec = getArcticTable().spec();
-    partitionProperty().forEach((partition, properties) -> {
-      String partitionToPath = spec.partitionToPath(partition);
-      if (partitionToPath.equals(partitionPlan.getPartition())) {
-        partitionPlan.addPartitionProperties(properties);
-      }
-    });
     List<TableFileScanHelper.FileScanResult> scan = tableFileScanHelper.scan();
     for (TableFileScanHelper.FileScanResult fileScanResult : scan) {
       partitionPlan.addFile(fileScanResult.file(), fileScanResult.deleteFiles());

--- a/ams/server/src/test/java/com/netease/arctic/server/optimizing/plan/MixedTablePlanTestBase.java
+++ b/ams/server/src/test/java/com/netease/arctic/server/optimizing/plan/MixedTablePlanTestBase.java
@@ -286,10 +286,6 @@ public abstract class MixedTablePlanTestBase extends TableTestBase {
   protected AbstractPartitionPlan buildPlanWithCurrentFiles() {
     TableFileScanHelper tableFileScanHelper = getTableFileScanHelper();
     AbstractPartitionPlan partitionPlan = getAndCheckPartitionPlan();
-    List<TableFileScanHelper.FileScanResult> scan = tableFileScanHelper.scan();
-    for (TableFileScanHelper.FileScanResult fileScanResult : scan) {
-      partitionPlan.addFile(fileScanResult.file(), fileScanResult.deleteFiles());
-    }
     PartitionSpec spec = getArcticTable().spec();
     partitionProperty().forEach((partition, properties) -> {
       String partitionToPath = spec.partitionToPath(partition);
@@ -297,6 +293,10 @@ public abstract class MixedTablePlanTestBase extends TableTestBase {
         partitionPlan.addPartitionProperties(properties);
       }
     });
+    List<TableFileScanHelper.FileScanResult> scan = tableFileScanHelper.scan();
+    for (TableFileScanHelper.FileScanResult fileScanResult : scan) {
+      partitionPlan.addFile(fileScanResult.file(), fileScanResult.deleteFiles());
+    }
     return partitionPlan;
   }
 

--- a/core/src/main/java/com/netease/arctic/utils/TablePropertyUtil.java
+++ b/core/src/main/java/com/netease/arctic/utils/TablePropertyUtil.java
@@ -21,6 +21,7 @@ package com.netease.arctic.utils;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netease.arctic.table.ArcticTable;
 import com.netease.arctic.table.KeyedTable;
 import com.netease.arctic.table.TableProperties;
 import com.netease.arctic.table.UnkeyedTable;
@@ -123,6 +124,31 @@ public class TablePropertyUtil {
       }
     });
 
+    return result;
+  }
+
+  public static Map<String, String> getPartitionProperties(ArcticTable arcticTable, String partitionPath) {
+    return getPartitionProperties(
+        arcticTable.isKeyedTable() ? arcticTable.asKeyedTable().baseTable() : arcticTable.asUnkeyedTable(),
+        partitionPath);
+  }
+
+  public static Map<String, String> getPartitionProperties(UnkeyedTable unkeyedTable, String partitionPath) {
+    StructLike partitionData;
+    if (unkeyedTable.spec().isUnpartitioned()) {
+      partitionData = TablePropertyUtil.EMPTY_STRUCT;
+    } else {
+      partitionData = ArcticDataFiles.data(unkeyedTable.spec(), partitionPath);
+    }
+    return getPartitionProperties(unkeyedTable, partitionData);
+  }
+
+  public static Map<String, String> getPartitionProperties(UnkeyedTable unkeyedTable, StructLike partitionData) {
+    Map<String, String> result = Maps.newHashMap();
+    StructLikeMap<Map<String, String>> partitionProperty = unkeyedTable.partitionProperty();
+    if (partitionProperty.containsKey(partitionData)) {
+      result = partitionProperty.get(partitionData);
+    }
     return result;
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://arctic.netease.com/ch/contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/arctic/issues, add '[ARCTIC-XXXX]' in your PR title, e.g., '[ARCTIC-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][ARCTIC #XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
-->

fix #1883 

## Brief change log

  - filter files when adding files to `PartitionEvaluator` and `AbstractPartitionPlan`
  - split tasks based on rewriteFiles and rewritePosFiles instead of fragment files and segment files
  - remove `taskNeedExecute` after splitting tasks
  - remove `addPartitionProperties` from `PartitionEvaluator`, add it to the constructor

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
