### PR TITLE
[AMORO-1864]  fix metadata file has not been deleted

### DIFF
--- a/ams/server/src/main/java/com/netease/arctic/server/table/executor/OrphanFilesCleaningExecutor.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/table/executor/OrphanFilesCleaningExecutor.java
@@ -368,7 +368,7 @@ public class OrphanFilesCleaningExecutor extends BaseTableExecutor {
           fileInfo.createdAtMillis() < lastTime &&
           (excludeRegex == null || !excludeRegex.matcher(
               TableFileUtil.getFileName(fileInfo.location())).matches())) {
-        pio.deleteFile(uriPath);
+        pio.deleteFile(fileInfo.location());
         count += 1;
       }
     }


### PR DESCRIPTION
Why are the changes needed?
fix https://github.com/NetEase/amoro/issues/1864

Brief change log
filter files when adding files to PartitionEvaluator and AbstractPartitionPlan
split tasks based on rewriteFiles and rewritePosFiles instead of fragment files and segment files
remove taskNeedExecute after splitting tasks
How was this patch tested?
 Add some test cases that check the changes thoroughly including negative and positive cases if possible

 Add screenshots for manual tests if appropriate

 Run test locally before making a pull request