### PR TITLE
[AMORO-1864]  fix metadata file has not been deleted

### DIFF
--- a/ams/server/src/main/java/com/netease/arctic/server/table/executor/OrphanFilesCleaningExecutor.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/table/executor/OrphanFilesCleaningExecutor.java
@@ -368,7 +368,7 @@ public class OrphanFilesCleaningExecutor extends BaseTableExecutor {
           fileInfo.createdAtMillis() < lastTime &&
           (excludeRegex == null || !excludeRegex.matcher(
               TableFileUtil.getFileName(fileInfo.location())).matches())) {
-        pio.deleteFile(uriPath);
+        pio.deleteFile(fileInfo.location());
         count += 1;
       }
     }


### PR DESCRIPTION
 

## Why are the changes needed?
fix #1864
 

## Brief change log

fix delete metadatafile uri to `fileInfo.location()`

## How was this patch tested?
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x]  Run test locally before making a pull request

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
