### PR TITLE
[AMORO-1335]Amoro AMS Support On K8S

### DIFF
--- a/charts/amoro/.helmignore
+++ b/charts/amoro/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/amoro/Chart.yaml
+++ b/charts/amoro/Chart.yaml
@@ -1,0 +1,27 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: v2
+name: amoro
+description: A Helm chart for Amoro
+type: application
+version: 0.1.0
+appVersion: "0.5.0"
+home: https://amoro.netease.com/
+icon: https://amoro.netease.com/img/amoro-logo-icon.png
+sources:
+  - https://github.com/NetEase/amoro

--- a/charts/amoro/README.md
+++ b/charts/amoro/README.md
@@ -1,0 +1,59 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# Helm Chart for Amoro
+
+[Amoro](https://amoro.netease.com) is a Lakehouse management system built on open data lake formats.
+Working with compute engines including Flink, Spark, and Trino, Amoro brings pluggable and self-managed features for Lakehouse to provide out-of-the-box data warehouse experience, 
+and helps data platforms or products easily build infra-decoupled, stream-and-batch-fused and lake-native architecture.
+
+
+## Introduction
+
+This chart will bootstrap an [Amoro](https://amoro.netease.com) deployment on a [Kubernetes](http://kubernetes.io)
+cluster using the [Helm](https://helm.sh) package manager.
+
+## Requirements
+
+- Kubernetes cluster
+- Helm 3.0+
+
+## Template rendering
+
+When you want to test the template rendering, but not actually install anything. [Debugging templates](https://helm.sh/docs/chart_template_guide/debugging/) provide a quick way of viewing the generated content without YAML parse errors blocking.
+
+There are two ways to render templates. It will return the rendered template to you so you can see the output.
+
+- Local rendering chart templates
+```shell
+helm template --debug ../amoro
+```
+- Server side rendering chart templates
+```shell
+helm install --dry-run --debug --generate-name ../amoro
+```
+<!-- ## Features -->
+
+## Documentation
+
+Configuration guide documentation for Amoro lives [on the website](https://amoro.netease.com/docs/latest). (Not just for Helm Chart)
+
+## Contributing
+
+Want to help build Amoro? Check out our [contributing documentation](https://amoro.netease.com/join-community).

--- a/charts/amoro/templates/NOTES.txt
+++ b/charts/amoro/templates/NOTES.txt
@@ -1,0 +1,31 @@
+{{/*
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
+
+The Amoro Helm chart has been installed!
+
+If you want to go ams web ui,you can use this cmd forward to local:
+
+ $ kubectl --namespace {{ .Release.Namespace }} port-forward services/{{ .Release.Name }}-rest {{ .Values.server.rest.port}}:{{ .Values.server.rest.port}}
+
+Additional Resources Docs
+
+================================================================================================================
+
+        * Documentation: https://amoro.netease.com/docs/latest/
+        * Version build Info : https://github.com/NetEase/amoro/releases/tag/v{{ .Chart.AppVersion }}
+
+================================================================================================================

--- a/charts/amoro/templates/_helpers.tpl
+++ b/charts/amoro/templates/_helpers.tpl
@@ -1,0 +1,33 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "amoro.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "amoro.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "amoro.labels" -}}
+helm.sh/chart: {{ include "amoro.chart" . }}
+{{ include "amoro.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "amoro.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "amoro.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/amoro/templates/amoro-configmap.yaml
+++ b/charts/amoro/templates/amoro-configmap.yaml
@@ -1,0 +1,132 @@
+{{/*
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    {{- include "amoro.labels" . | nindent 4 }}
+data:
+  ## Helm chart provided Amoro configurations
+  config.yaml: |
+    ams:
+      admin-username: admin
+      admin-password: admin
+      server-bind-host: "0.0.0.0"
+      server-expose-host: "127.0.0.1"
+
+      thrift-server:
+        max-message-size: 104857600 # 100MB
+        selector-thread-count: 2
+        selector-queue-size: 4
+        table-service:
+          bind-port: {{ .Values.server.table.port }}
+          worker-thread-count: 20
+        optimizing-service:
+          bind-port: {{ .Values.server.optimizing.port }}
+
+      http-server:
+        bind-port: {{ .Values.server.rest.port }}
+
+      refresh-external-catalogs:
+        interval: 180000 # 3min
+
+      refresh-tables:
+        thread-count: 10
+        interval: 60000 # 1min
+
+      self-optimizing:
+        commit-thread-count: 10
+
+      optimizer:
+        heart-beat-timeout: 60000 # 1min
+        task-ack-timeout: 30000 # 30s
+
+      blocker:
+        timeout: 60000 # 1min
+
+      # optional features
+      expire-snapshots:
+        enabled: true
+        thread-count: 10
+
+      clean-orphan-files:
+        enabled: true
+        thread-count: 10
+
+      sync-hive-tables:
+        enabled: true
+        thread-count: 10
+
+      database:
+        type: {{ .Values.amoroConf.database.type }}
+        url: {{ .Values.amoroConf.database.url }}
+        jdbc-driver-class: {{ .Values.amoroConf.database.driver | quote }}
+        {{- if eq .Values.amoroConf.database.type "mysql" }}
+        username: {{ .Values.amoroConf.database.username | quote }}
+        password: {{ .Values.amoroConf.database.password | quote }}
+        {{- end }}
+
+      #  MySQL database configuration.
+      #  database:
+      #    type: mysql
+      #    jdbc-driver-class: com.mysql.cj.jdbc.Driver
+      #    url: jdbc:mysql://127.0.0.1:3306/db?useUnicode=true&characterEncoding=UTF8&autoReconnect=true&useAffectedRows=true&useSSL=false
+      #    username: root
+      #    password: root
+
+      terminal:
+        backend: local
+        local.spark.sql.iceberg.handle-timestamp-without-timezone: false
+
+      #  Kyuubi terminal backend configuration.
+      #  terminal:
+      #    backend: kyuubi
+      #    kyuubi.jdbc.url: jdbc:hive2://127.0.0.1:10009/
+
+    #  High availability configuration.
+    #  ha:
+    #    enabled: true
+    #    cluster-name: default
+    #    zookeeper-address: 127.0.0.1:2181,127.0.0.1:2182,127.0.0.1:2183
+
+    containers:
+      - name: localContainer
+        container-impl: com.netease.arctic.optimizer.LocalOptimizerContainer
+        properties:
+          export.JAVA_HOME: "/opt/java"   # JDK environment
+
+            #containers:
+            #  - name: flinkContainer
+            #    container-impl: com.netease.arctic.optimizer.FlinkOptimizerContainer
+            #    properties:
+            #      flink-home: "/opt/flink/"                                     # Flink install home
+            #      export.JVM_ARGS: "-Djava.security.krb5.conf=/opt/krb5.conf"   # Flink launch jvm args, like kerberos config when ues kerberos
+            #      export.HADOOP_CONF_DIR: "/etc/hadoop/conf/"                   # Hadoop config dir
+            #      export.HADOOP_USER_NAME: "hadoop"                             # Hadoop user submit on yarn
+          #      export.FLINK_CONF_DIR: "/etc/hadoop/conf/"                    # Flink config dir
+
+      ## User provided Amoro configurations
+    {{- with .Values.amoroConf.amoroDefaults }}
+      {{- tpl . $ | nindent 4 }}
+    {{- end }}
+  {{- with .Values.amoroConf.log4j2 }}
+  log4j2.xml: |
+    {{- tpl . $ | nindent 4 }}
+---
+  {{- end }}

--- a/charts/amoro/templates/amoro-deployment.yaml
+++ b/charts/amoro/templates/amoro-deployment.yaml
@@ -1,0 +1,119 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $.Release.Name }}
+  labels:
+    {{- include "amoro.labels" . | nindent 4 }}
+spec:
+  {{/* TODO If Support Replica can be use more than 1 */}}
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "amoro.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/conf: {{ include (print $.Template.BasePath "/amoro-configmap.yaml") . | sha256sum }}
+      labels:
+        {{- include "amoro.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if or .Values.serviceAccount.name .Values.serviceAccount.create }}
+      serviceAccountName: {{ .Values.serviceAccount.name | default .Release.Name }}
+      {{- end }}
+      containers:
+        - name: amoro-ams
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.command }}
+          command: {{- tpl (toYaml .) $ | nindent 12 }}
+            {{- end }}
+            {{- with .Values.args }}
+          args: {{- tpl (toYaml .) $ | nindent 12 }}
+            {{- end }}
+          env:
+           {{- with .Values.env }}
+           {{- tpl (toYaml .) $ | nindent 12 }}
+            {{- end }}
+          envFrom:
+           {{- with .Values.envFrom }}
+          {{- tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: rest
+              containerPort: {{ .Values.server.rest.port }}
+            - name: table
+              containerPort: {{ .Values.server.table.port }}
+            - name: optimizing
+              containerPort: {{ .Values.server.optimizing.port }}
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /health/status
+              port: rest
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+              {{- end }}
+              {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: /versionInfo
+              port: rest
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: conf
+              mountPath: {{ .Values.amoroDir }}/amoro-{{ .Chart.AppVersion }}/conf/config.yaml
+              readOnly: true
+              subPath: "config.yaml"
+              {{- with .Values.volumeMounts }}
+                {{- tpl (toYaml .) $ | nindent 12 }}
+              {{- end }}
+            {{- if or .Values.amoroConf.log4j2 }}
+            - name: conf
+              mountPath: {{ .Values.amoroDir }}/amoro-{{ .Chart.AppVersion }}/conf/log4j2.xml
+              readOnly: true
+              subPath: "log4j2.xml"
+              {{- with .Values.volumeMounts }}
+                {{- tpl (toYaml .) $ | nindent 12 }}
+              {{- end }}
+            {{- end }}
+          {{- with .Values.containers }}
+            {{- tpl (toYaml .) $ | nindent 8 }}
+          {{- end }}
+      volumes:
+        - name: conf
+          configMap:
+            name: {{ .Release.Name }}
+        {{- with .Values.volumes }}
+          {{- tpl (toYaml .) $ | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.securityContext }}
+      securityContext: {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/amoro/templates/amoro-role.yaml
+++ b/charts/amoro/templates/amoro-role.yaml
@@ -1,0 +1,26 @@
+{{/*
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
+
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    {{- include "amoro.labels" . | nindent 4 }}
+rules: {{- toYaml .Values.rbac.rules | nindent 2 }}
+{{- end }}

--- a/charts/amoro/templates/amoro-rolebinding.yaml
+++ b/charts/amoro/templates/amoro-rolebinding.yaml
@@ -1,0 +1,32 @@
+{{/*
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
+
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    {{- include "amoro.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.serviceAccount.name | default .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}
+{{- end }}

--- a/charts/amoro/templates/amoro-service.yaml
+++ b/charts/amoro/templates/amoro-service.yaml
@@ -1,0 +1,42 @@
+{{/*
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
+
+{{- range $name, $frontend := .Values.server }}
+{{- if $frontend.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $.Release.Name }}-{{ $name }}
+  labels:
+    {{- include "amoro.labels" $ | nindent 4 }}
+  {{- with $frontend.service.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ $frontend.service.type }}
+  ports:
+    - name: {{ tpl $name $ }}
+      port: {{ tpl $frontend.service.port $ }}
+      {{- if and (eq $frontend.service.type "NodePort") ($frontend.service.nodePort) }}
+      nodePort: {{ $frontend.service.nodePort }}
+      {{- end }}
+      targetPort: {{ $frontend.port }}
+  selector:
+    {{- include "amoro.selectorLabels"  $ | nindent 4 }}
+---
+{{- end }}
+{{- end }}

--- a/charts/amoro/templates/amoro-serviceaccount.yaml
+++ b/charts/amoro/templates/amoro-serviceaccount.yaml
@@ -1,0 +1,29 @@
+{{/*
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
+
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name | default .Release.Name }}
+  labels:
+    {{- include "amoro.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/amoro/values.yaml
+++ b/charts/amoro/values.yaml
@@ -1,0 +1,153 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+image:
+  repository: arctic163/ams
+  pullPolicy: IfNotPresent
+  tag: ""
+
+imagePullSecrets: [ ]
+#nameOverride: ""
+#fullnameOverride: ""
+
+# Role-based access control
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+  # RBAC rules
+  rules:
+    - apiGroups: [ "" ]
+      resources: [ "pods" ]
+      verbs: [ "create", "list", "delete" ]
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: { }
+  # Specifies ServiceAccount name to be used (created if `create: true`)
+  name: ~
+
+server:
+  # AMS REST Service
+  rest:
+    enabled: true
+    port: 1630
+    service:
+      type: ClusterIP
+      port: "{{ .Values.server.rest.port }}"
+      nodePort: ~
+      annotations: { }
+  # AMS Thrift Server For table services
+  table:
+    enabled: true
+    port: 1260
+    service:
+      type: ClusterIP
+      port: "{{ .Values.server.table.port }}"
+      nodePort: ~
+      annotations: { }
+  # AMS Thrift Server For optimizing services
+  optimizing:
+    enabled: true
+    port: 1261
+    service:
+      type: ClusterIP
+      port: "{{ .Values.server.optimizing.port }}"
+      nodePort: ~
+      annotations: { }
+
+# amoro Base Dir
+amoroDir: "/usr/local/ams"
+# AMS configurations files
+amoroConf:
+  # ams database properties,default is derby. If production,suggest use mysql
+  database:
+    type: derby
+    driver: org.apache.derby.jdbc.EmbeddedDriver
+    url: jdbc:derby:/tmp/amoro/derby;create=true
+  #    type: mysql
+  #    jdbc-driver-class: com.mysql.cj.jdbc.Driver
+  #    url: jdbc:mysql://127.0.0.1:3306/db?useUnicode=true&characterEncoding=UTF8&autoReconnect=true&useAffectedRows=true&useSSL=false
+  #    username: admin
+  #    password: admin
+
+  # The value (templated string) is used for conf.yaml file
+  # See https://github.com/NetEase/amoro/blob/master/dist/src/main/arctic-bin/conf/config.yaml for more details
+  #
+  amoroDefaults: ~
+
+  # The value (templated string) is used for conf/log4j2.xml file
+  # See example at conf/log4j2.xml.template https://github.com/NetEase/amoro/blob/master/dist/src/main/arctic-bin/conf/log4j2.xml for more details
+  log4j2: ~
+
+# Command to launch AMS server (templated)
+command: ~
+# Arguments to launch AMS server (templated)
+args: ~
+
+# Environment variables (templated)
+env: [ ]
+# Environment variables from ConfigMaps and Secrets (templated)
+envFrom: [ ]
+
+# Additional volumes for AMS pod (templated)
+volumes: [ ]
+# Additional volumeMounts for AMS container (templated)
+volumeMounts: [ ]
+
+# Additional init containers for AMS pod (templated)
+initContainers: [ ]
+# Additional containers for AMS pod (templated)
+containers: [ ]
+
+# Liveness probe
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 40
+  periodSeconds: 10
+  timeoutSeconds: 2
+  failureThreshold: 10
+  successThreshold: 1
+
+# Readiness probe
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 2
+  failureThreshold: 10
+  successThreshold: 1
+
+# Resource requests and limits for Amoro pods
+resources: { }
+#  resources:
+#    requests:
+#      cpu: 2
+#      memory: 4Gi
+#    limits:
+#      cpu: 4
+#      memory: 10Gi
+
+# Constrain Amoro pods to nodes with specific node labels
+nodeSelector: { }
+# Allow to schedule Amoro pods on nodes with matching taints
+tolerations: [ ]
+# Constrain Amoro pods to nodes by complex affinity/anti-affinity rules
+affinity: { }
+# Amoro pods security context
+securityContext: { }


### PR DESCRIPTION
## Why are the changes needed?

AMS Run On K8S

Close #1335.

## Brief change log

- add helm chart for amoro
- ams running on k8s

## How was this patch tested?

- [x] ams log4j2 and config.xml can be rewrite
- [x] ams server and web ui on k8s open normal
- [x] Run test locally on k8s before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes)
- If yes, how is the feature documented? (docs)
