### PR TITLE
[AMORO-1912] Roll back the refresh when constructing UGI

### DIFF
--- a/core/src/main/java/com/netease/arctic/table/TableMetaStore.java
+++ b/core/src/main/java/com/netease/arctic/table/TableMetaStore.java
@@ -426,7 +426,12 @@ public class TableMetaStore implements Serializable {
     return String.format("%s/%s", confPath.toString(), confName);
   }
 
-  private static Configuration buildConfiguration(TableMetaStore metaStore) {
+  private Configuration buildConfiguration(TableMetaStore metaStore) {
+    if (TableMetaStore.AUTH_METHOD_KERBEROS.equals(metaStore.authMethod)) {
+      generateKrbConfPath();
+      String krbConfFile = saveConfInPath(confCachePath, KRB_CONF_FILE_NAME, krbConf);
+      System.setProperty(KRB5_CONF_PROPERTY, krbConfFile);
+    }
     Configuration configuration = new Configuration();
     configuration.addResource(new ByteArrayInputStream(metaStore.getCoreSite()));
     configuration.addResource(new ByteArrayInputStream(metaStore.getHdfsSite()));

--- a/core/src/main/java/com/netease/arctic/table/TableMetaStore.java
+++ b/core/src/main/java/com/netease/arctic/table/TableMetaStore.java
@@ -35,6 +35,7 @@ import org.apache.iceberg.relocated.com.google.common.hash.Hashing;
 import org.apache.iceberg.relocated.com.google.common.io.ByteStreams;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import sun.security.krb5.KrbException;
 
 import java.io.ByteArrayInputStream;
 import java.io.FileInputStream;
@@ -228,7 +229,7 @@ public class TableMetaStore implements Serializable {
           constructUgi();
         }
         LOG.info("Complete to build ugi {}", authInformation());
-      } catch (IOException e) {
+      } catch (IOException | KrbException e) {
         throw new RuntimeException("Fail to init user group information", e);
       }
     } else {
@@ -325,11 +326,12 @@ public class TableMetaStore implements Serializable {
     return authInformation;
   }
 
-  private void constructUgi() throws IOException {
+  private void constructUgi() throws IOException, KrbException {
     String krbConfFile = saveConfInPath(confCachePath, KRB_CONF_FILE_NAME, krbConf);
     String keyTabFile = saveConfInPath(confCachePath, KEY_TAB_FILE_NAME, krbKeyTab);
     System.clearProperty(HADOOP_USER_PROPERTY);
     System.setProperty(KRB5_CONF_PROPERTY, krbConfFile);
+    sun.security.krb5.Config.refresh();
     UserGroupInformation.setConfiguration(getConfiguration());
     KerberosName.resetDefaultRealm();
     ugi = UserGroupInformation.loginUserFromKeytabAndReturnUGI(krbPrincipal, keyTabFile);
@@ -427,11 +429,6 @@ public class TableMetaStore implements Serializable {
   }
 
   private Configuration buildConfiguration(TableMetaStore metaStore) {
-    if (TableMetaStore.AUTH_METHOD_KERBEROS.equals(metaStore.authMethod)) {
-      generateKrbConfPath();
-      String krbConfFile = saveConfInPath(confCachePath, KRB_CONF_FILE_NAME, krbConf);
-      System.setProperty(KRB5_CONF_PROPERTY, krbConfFile);
-    }
     Configuration configuration = new Configuration();
     configuration.addResource(new ByteArrayInputStream(metaStore.getCoreSite()));
     configuration.addResource(new ByteArrayInputStream(metaStore.getHdfsSite()));

--- a/core/src/main/java/com/netease/arctic/table/TableMetaStore.java
+++ b/core/src/main/java/com/netease/arctic/table/TableMetaStore.java
@@ -428,7 +428,7 @@ public class TableMetaStore implements Serializable {
     return String.format("%s/%s", confPath.toString(), confName);
   }
 
-  private Configuration buildConfiguration(TableMetaStore metaStore) {
+  private static Configuration buildConfiguration(TableMetaStore metaStore) {
     Configuration configuration = new Configuration();
     configuration.addResource(new ByteArrayInputStream(metaStore.getCoreSite()));
     configuration.addResource(new ByteArrayInputStream(metaStore.getHdfsSite()));

--- a/docs/engines/trino.md
+++ b/docs/engines/trino.md
@@ -25,6 +25,10 @@ please refer to the documentation at [Iceberg Connector](https://trino.io/docs/c
 connector.name=arctic
 arctic.url=thrift://{ip}:{port}/{catalogName}
 ```
+- Configure the JVM configuration file for Trino in the {trino_home}/etc directory named `jvm.config` :
+```tex
+--add-exports=java.security.jgss/sun.security.krb5=ALL-UNNAMED
+```
 
 ### Support SQL statement
 

--- a/docs/engines/trino.md
+++ b/docs/engines/trino.md
@@ -20,7 +20,6 @@ please refer to the documentation at [Iceberg Connector](https://trino.io/docs/c
 - Create the {trino_home}/plugin/amoro directory in the Trino installation package, 
   and extract the contents of the amoro-trino package trino-amoro-xx-SNAPSHOT.tar.gz to the {trino_home}/plugin/amoro directory.
 - Configure the Catalog configuration file for Amoro in the {trino_home}/etc/catalog directory, for example:
-- 
 ```tex
 connector.name=arctic
 arctic.url=thrift://{ip}:{port}/{catalogName}


### PR DESCRIPTION
## Why are the changes needed?
Fix #1912.

## Brief change log

Roll back the ` sun.security.krb5.Config.refresh();` and add docs for Trino.

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable)
