### PR TITLE
[AMORO-1914] Override `org.apache.iceberg.Table#name` for some classes and `toString` for `TaskRuntime`

### DIFF
--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/TaskRuntime.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/TaskRuntime.java
@@ -34,6 +34,7 @@ import com.netease.arctic.server.persistence.StatedPersistentBase;
 import com.netease.arctic.server.persistence.TaskFilesPersistence;
 import com.netease.arctic.server.persistence.mapper.OptimizingMapper;
 import com.netease.arctic.utils.SerializationUtil;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -270,6 +271,24 @@ public class TaskRuntime extends StatedPersistentBase {
 
   public long getTableId() {
     return tableId;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("tableId", tableId)
+        .add("partition", partition)
+        .add("taskId", taskId.getTaskId())
+        .add("status", status)
+        .add("retry", retry)
+        .add("startTime", startTime)
+        .add("endTime", endTime)
+        .add("costTime", costTime)
+        .add("optimizingThread", optimizingThread)
+        .add("failReason", failReason)
+        .add("summary", summary)
+        .add("properties", properties)
+        .toString();
   }
 
   private void validThread(OptimizingQueue.OptimizingThread thread) {

--- a/core/src/main/java/com/netease/arctic/table/BasicUnkeyedTable.java
+++ b/core/src/main/java/com/netease/arctic/table/BasicUnkeyedTable.java
@@ -114,6 +114,11 @@ public class BasicUnkeyedTable implements UnkeyedTable, HasTableOperations {
   }
 
   @Override
+  public String name() {
+    return icebergTable.name();
+  }
+
+  @Override
   public Map<Integer, Schema> schemas() {
     return icebergTable.schemas();
   }

--- a/trino/src/main/java/com/netease/arctic/trino/ArcticCatalogSupportTableSuffix.java
+++ b/trino/src/main/java/com/netease/arctic/trino/ArcticCatalogSupportTableSuffix.java
@@ -193,6 +193,11 @@ public class ArcticCatalogSupportTableSuffix implements ArcticCatalog {
     }
 
     @Override
+    public String name() {
+      return table.name();
+    }
+
+    @Override
     public Map<Integer, Schema> schemas() {
       return table.schemas();
     }


### PR DESCRIPTION
…Runtime` did not override `toString`

<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.netease.com/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close #1914

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->
1. `BasicUnkeyedTable` and `ChangeTableWithExternalSchemas` override `name` method
2. `TaskRuntime` override `toString`

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
