### PR TITLE
[AMORO-1242] Fix refreshing a large number of tables during optimizing plan

### DIFF
--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/service/impl/OptimizeQueueService.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/service/impl/OptimizeQueueService.java
@@ -731,6 +731,10 @@ public class OptimizeQueueService extends IJDBCService implements Closeable {
       for (TableIdentifier tableIdentifier : tableSort) {
         try {
           TableOptimizeItem tableItem = ServiceContainer.getOptimizeService().getTableOptimizeItem(tableIdentifier);
+          if (tableItem.getTableOptimizeRuntime().getOptimizeStatus() != TableOptimizeRuntime.OptimizeStatus.Pending) {
+            // only table in pending should plan
+            continue;
+          }
           ArcticTable arcticTable = tableItem.getArcticTable(true);
 
           Map<String, String> properties = arcticTable.properties();
@@ -762,11 +766,6 @@ public class OptimizeQueueService extends IJDBCService implements Closeable {
             } else {
               continue;
             }
-          }
-
-          if (tableItem.getTableOptimizeRuntime().getOptimizeStatus() != TableOptimizeRuntime.OptimizeStatus.Pending) {
-            // only table in pending should plan
-            continue;
           }
 
           OptimizePlanResult optimizePlanResult = OptimizePlanResult.EMPTY;

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/service/impl/OptimizeQueueService.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/service/impl/OptimizeQueueService.java
@@ -769,6 +769,7 @@ public class OptimizeQueueService extends IJDBCService implements Closeable {
           }
 
           OptimizePlanResult optimizePlanResult = OptimizePlanResult.EMPTY;
+          long startPlanTime = System.currentTimeMillis();
           if (tableItem.startPlanIfNot()) {
             try {
               if (TableTypeUtil.isIcebergTableFormat(arcticTable)) {
@@ -778,13 +779,13 @@ public class OptimizeQueueService extends IJDBCService implements Closeable {
               }
             } finally {
               tableItem.finishPlan();
+              LOG.info("{} finish plan cost {} ms, get {} tasks", tableItem.getTableIdentifier(),
+                  System.currentTimeMillis() - startPlanTime, optimizePlanResult.getOptimizeTasks().size());
             }
           }
 
           if (!optimizePlanResult.isEmpty()) {
             initTableOptimizeRuntime(tableItem, optimizePlanResult);
-            LOG.debug("{} after plan get {} tasks", tableItem.getTableIdentifier(),
-                optimizePlanResult.getOptimizeTasks().size());
 
             List<OptimizeTaskItem> toExecuteTasks = addTask(tableItem, optimizePlanResult.getOptimizeTasks());
             if (!toExecuteTasks.isEmpty()) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.netease.com/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close #1242 . 

 This PR (#1284) has achieved only planning the pending tables to improve plan efficiency, but it still refreshes the idle tables. When there are many tables, this can become a bottleneck.

In the production scenario, we observed more than 1,00 tables were refreshed for each plan, which cost 10-20s. 
However, plan for each table only cost 1-2s.


## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- check pending status before refresh table
- modify some logs for plan cost of each table

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / **no**)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
