### PR TITLE
[AMORO-1935] 0.4.x introduce a table property for task spliting size of self-optimizing

### DIFF
--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/AbstractOptimizePlan.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/AbstractOptimizePlan.java
@@ -195,6 +195,12 @@ public abstract class AbstractOptimizePlan {
     }
   }
 
+  protected long getTaskSize() {
+    return PropertyUtil.propertyAsLong(arcticTable.properties(),
+        TableProperties.SELF_OPTIMIZING_MAX_TASK_FILE_SIZE,
+        TableProperties.SELF_OPTIMIZING_MAX_TASK_FILE_SIZE_DEFAULT);
+  }
+
   protected interface PartitionWeight extends Comparable<PartitionWeight> {
 
   }

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/AbstractOptimizePlan.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/AbstractOptimizePlan.java
@@ -197,8 +197,8 @@ public abstract class AbstractOptimizePlan {
 
   protected long getTaskSize() {
     return PropertyUtil.propertyAsLong(arcticTable.properties(),
-        TableProperties.SELF_OPTIMIZING_MAX_TASK_FILE_SIZE,
-        TableProperties.SELF_OPTIMIZING_MAX_TASK_FILE_SIZE_DEFAULT);
+        TableProperties.SELF_OPTIMIZING_MAX_TASK_SIZE,
+        TableProperties.SELF_OPTIMIZING_MAX_TASK_SIZE_DEFAULT);
   }
 
   protected interface PartitionWeight extends Comparable<PartitionWeight> {

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/MajorOptimizePlan.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/MajorOptimizePlan.java
@@ -170,12 +170,8 @@ public class MajorOptimizePlan extends AbstractArcticOptimizePlan {
     List<DeleteFile> posDeleteFiles = getPosDeleteFilesFromFileTree(partition);
     if (nodeTaskNeedBuild(partition, posDeleteFiles, baseFiles)) {
       // for unkeyed table, tasks can be bin-packed
-      long taskSize = CompatiblePropertyUtil.propertyAsLong(arcticTable.properties(),
-          TableProperties.SELF_OPTIMIZING_TARGET_SIZE,
-          TableProperties.SELF_OPTIMIZING_TARGET_SIZE_DEFAULT);
-      Long sum = baseFiles.stream().map(DataFile::fileSizeInBytes).reduce(0L, Long::sum);
-      int taskCnt = (int) (sum / taskSize) + 1;
-      List<List<DataFile>> packed = new BinPacking.ListPacker<DataFile>(taskSize, taskCnt, true)
+      long taskSize = getTaskSize();
+      List<List<DataFile>> packed = new BinPacking.ListPacker<DataFile>(taskSize, Integer.MAX_VALUE, true)
           .pack(baseFiles, DataFile::fileSizeInBytes);
       for (List<DataFile> files : packed) {
         if (CollectionUtils.isNotEmpty(files)) {

--- a/ams/ams-server/src/test/java/com/netease/arctic/ams/server/optimize/TestIcebergFullOptimizePlan.java
+++ b/ams/ams-server/src/test/java/com/netease/arctic/ams/server/optimize/TestIcebergFullOptimizePlan.java
@@ -109,7 +109,7 @@ public class TestIcebergFullOptimizePlan extends TestIcebergBase {
     long targetSize = dataFiles.get(0).fileSizeInBytes() * packFileCnt + 100;
     table.updateProperties()
         .set(TableProperties.SELF_OPTIMIZING_MAJOR_TRIGGER_DUPLICATE_RATIO, "0")
-        .set(TableProperties.SELF_OPTIMIZING_TARGET_SIZE, targetSize + "")
+        .set(TableProperties.SELF_OPTIMIZING_MAX_TASK_FILE_SIZE, targetSize + "")
         .commit();
     insertEqDeleteFiles(table, 1);
     insertPosDeleteFiles(table, dataFiles);

--- a/ams/ams-server/src/test/java/com/netease/arctic/ams/server/optimize/TestIcebergFullOptimizePlan.java
+++ b/ams/ams-server/src/test/java/com/netease/arctic/ams/server/optimize/TestIcebergFullOptimizePlan.java
@@ -109,7 +109,7 @@ public class TestIcebergFullOptimizePlan extends TestIcebergBase {
     long targetSize = dataFiles.get(0).fileSizeInBytes() * packFileCnt + 100;
     table.updateProperties()
         .set(TableProperties.SELF_OPTIMIZING_MAJOR_TRIGGER_DUPLICATE_RATIO, "0")
-        .set(TableProperties.SELF_OPTIMIZING_MAX_TASK_FILE_SIZE, targetSize + "")
+        .set(TableProperties.SELF_OPTIMIZING_MAX_TASK_SIZE, targetSize + "")
         .commit();
     insertEqDeleteFiles(table, 1);
     insertPosDeleteFiles(table, dataFiles);

--- a/ams/ams-server/src/test/java/com/netease/arctic/ams/server/optimize/TestMajorOptimizePlan.java
+++ b/ams/ams-server/src/test/java/com/netease/arctic/ams/server/optimize/TestMajorOptimizePlan.java
@@ -287,11 +287,10 @@ public class TestMajorOptimizePlan extends TestBaseOptimizeBase {
     Pair<Snapshot, List<DataFile>> insertBaseResult = insertTableBaseDataFiles(testNoPartitionTable);
     List<DataFile> baseDataFiles = insertBaseResult.second();
     long fileSize = baseDataFiles.get(0).fileSizeInBytes();
-    // set task_size to be 2.5 * file_size, task_size = base_bucket * target_size = 2.5 * file_size
-    // base_bucket = 4, so target_size = file_size * 2.5 / 4 = file_size * 5 / 8
+    // set task_size to be 2.5 * file_size
     testNoPartitionTable.updateProperties()
         .set(TableProperties.BASE_FILE_INDEX_HASH_BUCKET, "4")
-        .set(TableProperties.SELF_OPTIMIZING_TARGET_SIZE, fileSize * 5 / 8 + "")
+        .set(TableProperties.SELF_OPTIMIZING_MAX_TASK_FILE_SIZE, fileSize * 5 / 2 + "")
         .commit();
 
     List<FileScanTask> baseFiles = planBaseFiles(testNoPartitionTable);

--- a/ams/ams-server/src/test/java/com/netease/arctic/ams/server/optimize/TestMajorOptimizePlan.java
+++ b/ams/ams-server/src/test/java/com/netease/arctic/ams/server/optimize/TestMajorOptimizePlan.java
@@ -290,7 +290,7 @@ public class TestMajorOptimizePlan extends TestBaseOptimizeBase {
     // set task_size to be 2.5 * file_size
     testNoPartitionTable.updateProperties()
         .set(TableProperties.BASE_FILE_INDEX_HASH_BUCKET, "4")
-        .set(TableProperties.SELF_OPTIMIZING_MAX_TASK_FILE_SIZE, fileSize * 5 / 2 + "")
+        .set(TableProperties.SELF_OPTIMIZING_MAX_TASK_SIZE, fileSize * 5 / 2 + "")
         .commit();
 
     List<FileScanTask> baseFiles = planBaseFiles(testNoPartitionTable);

--- a/core/src/main/java/com/netease/arctic/table/TableProperties.java
+++ b/core/src/main/java/com/netease/arctic/table/TableProperties.java
@@ -92,6 +92,9 @@ public class TableProperties {
   public static final String SELF_OPTIMIZING_MAX_FILE_SIZE_BYTES = "self-optimizing.max-file-size-bytes";
   public static final long SELF_OPTIMIZING_MAX_FILE_SIZE_BYTES_DEFAULT = 8589934592L; // 8 GB
 
+  public static final String SELF_OPTIMIZING_MAX_TASK_FILE_SIZE = "self-optimizing.max-task-file-size-bytes";
+  public static final long SELF_OPTIMIZING_MAX_TASK_FILE_SIZE_DEFAULT = 1073741824L; // 1 GB
+
   public static final String SELF_OPTIMIZING_FRAGMENT_RATIO = "self-optimizing.fragment-ratio";
   public static final int SELF_OPTIMIZING_FRAGMENT_RATIO_DEFAULT = 8;
 

--- a/core/src/main/java/com/netease/arctic/table/TableProperties.java
+++ b/core/src/main/java/com/netease/arctic/table/TableProperties.java
@@ -92,8 +92,8 @@ public class TableProperties {
   public static final String SELF_OPTIMIZING_MAX_FILE_SIZE_BYTES = "self-optimizing.max-file-size-bytes";
   public static final long SELF_OPTIMIZING_MAX_FILE_SIZE_BYTES_DEFAULT = 8589934592L; // 8 GB
 
-  public static final String SELF_OPTIMIZING_MAX_TASK_FILE_SIZE = "self-optimizing.max-task-file-size-bytes";
-  public static final long SELF_OPTIMIZING_MAX_TASK_FILE_SIZE_DEFAULT = 1073741824L; // 1 GB
+  public static final String SELF_OPTIMIZING_MAX_TASK_SIZE = "self-optimizing.max-task-size-bytes";
+  public static final long SELF_OPTIMIZING_MAX_TASK_SIZE_DEFAULT = 1073741824L; // 1 GB
 
   public static final String SELF_OPTIMIZING_FRAGMENT_RATIO = "self-optimizing.fragment-ratio";
   public static final int SELF_OPTIMIZING_FRAGMENT_RATIO_DEFAULT = 8;

--- a/site/docs/ch/configurations.md
+++ b/site/docs/ch/configurations.md
@@ -17,6 +17,7 @@ Self-optimizing 配置对 Iceberg format, Mixed streaming format 都会生效。
 | self-optimizing.target-size                         | 134217728（128MB）| self-optimizing 的目标文件大小                                |
 | self-optimizing.max-file-count                      | 10000            | 一次 self-optimizing 最多处理的文件个数                           |               |
 | self-optimizing.max-file-size-bytes                 | 8589934592（8GB） | 一次 self-optimizing 最多处理的文件大小                           |               |
+| self-optimizing.max-task-file-size-bytes            | 1073741824（1GB） | self-optimizing task 大小                           |               |
 | self-optimizing.fragment-ratio                      | 8                | fragment 文件大小阈值，实际计算时取倒数与  self-optimizing.target-size 的值相乘                         |
 | self-optimizing.minor.trigger.file-count            | 12               | 触发 minor optimizing 的 fragment 最少文件数量             |
 | self-optimizing.minor.trigger.interval              | 3600000（1小时）  | 触发 minor optimizing 的最长时间间隔                        |

--- a/site/docs/ch/configurations.md
+++ b/site/docs/ch/configurations.md
@@ -17,7 +17,7 @@ Self-optimizing 配置对 Iceberg format, Mixed streaming format 都会生效。
 | self-optimizing.target-size                         | 134217728（128MB）| self-optimizing 的目标文件大小                                |
 | self-optimizing.max-file-count                      | 10000            | 一次 self-optimizing 最多处理的文件个数                           |               |
 | self-optimizing.max-file-size-bytes                 | 8589934592（8GB） | 一次 self-optimizing 最多处理的文件大小                           |               |
-| self-optimizing.max-task-file-size-bytes            | 1073741824（1GB） | self-optimizing task 大小                           |               |
+| self-optimizing.max-task-size-bytes                 | 1073741824（1GB） | self-optimizing task 大小                           |               |
 | self-optimizing.fragment-ratio                      | 8                | fragment 文件大小阈值，实际计算时取倒数与  self-optimizing.target-size 的值相乘                         |
 | self-optimizing.minor.trigger.file-count            | 12               | 触发 minor optimizing 的 fragment 最少文件数量             |
 | self-optimizing.minor.trigger.interval              | 3600000（1小时）  | 触发 minor optimizing 的最长时间间隔                        |


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.netease.com/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close #1935 .

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- add table property self-optimizing.max-task-file-size-bytes
- add to docs

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / **no**)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
