### PR TITLE
[AMORO-1931][Flink] Logstore supports 'group-offsets' and 'specific-o…

### DIFF
--- a/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/descriptors/ArcticValidator.java
+++ b/flink/v1.12/flink/src/main/java/com/netease/arctic/flink/table/descriptors/ArcticValidator.java
@@ -78,6 +78,8 @@ public class ArcticValidator extends ConnectorDescriptorValidator {
   public static final String SCAN_STARTUP_MODE_EARLIEST = "earliest";
   public static final String SCAN_STARTUP_MODE_LATEST = "latest";
   public static final String SCAN_STARTUP_MODE_TIMESTAMP = "timestamp";
+  public static final String SCAN_STARTUP_MODE_GROUP_OFFSETS = "group-offsets";
+  public static final String SCAN_STARTUP_MODE_SPECIFIC_OFFSETS = "specific-offsets";
 
   public static final ConfigOption<Boolean> ARCTIC_LOG_CONSISTENCY_GUARANTEE_ENABLE =
       ConfigOptions.key("log-store.consistency-guarantee.enabled")
@@ -135,12 +137,19 @@ public class ArcticValidator extends ConnectorDescriptorValidator {
               " \"timestamp\": start from user-supplied timestamp for each partition.",
           ARCTIC_READ_MODE, ARCTIC_READ_FILE, ARCTIC_READ_MODE, ARCTIC_READ_LOG));
 
-  public static final ConfigOption<Long> SCAN_STARTUP_TIMESTAMP_MILLIS =
-      ConfigOptions.key("scan.startup.timestamp-millis")
-          .longType()
-          .noDefaultValue()
-          .withDescription(
-              "Optional timestamp used in case of \"timestamp\" startup mode");
+  public static final ConfigOption<Long> SCAN_STARTUP_TIMESTAMP_MILLIS = ConfigOptions
+      .key("scan.startup.timestamp-millis")
+      .longType()
+      .noDefaultValue()
+      .withDescription(
+          "Optional timestamp used in case of \"timestamp\" startup mode");
+
+  public static final ConfigOption<String> SCAN_STARTUP_SPECIFIC_OFFSETS = ConfigOptions
+      .key("scan.startup.specific-offsets")
+      .stringType()
+      .noDefaultValue()
+      .withDescription(
+        "Optional timestamp used in case of \"timestamp\" startup mode");
 
   public static final ConfigOption<Boolean> SUBMIT_EMPTY_SNAPSHOTS = ConfigOptions
       .key("submit.empty.snapshots")

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSourceBuilder.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSourceBuilder.java
@@ -40,9 +40,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Properties;
 import java.util.Random;
 import java.util.Set;
@@ -50,8 +50,11 @@ import java.util.regex.Pattern;
 
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE_EARLIEST;
+import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE_GROUP_OFFSETS;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE_LATEST;
+import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE_SPECIFIC_OFFSETS;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE_TIMESTAMP;
+import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_SPECIFIC_OFFSETS;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_TIMESTAMP_MILLIS;
 import static com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil.fetchLogstorePrefixProperties;
 import static com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil.getLogTopic;
@@ -77,6 +80,8 @@ public class LogKafkaSourceBuilder {
   private static final String[] REQUIRED_CONFIGS = {
       ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, ConsumerConfig.GROUP_ID_CONFIG
   };
+  private static final String PARTITION = "partition";
+  private static final String OFFSET = "offset";
   // The subscriber specifies the partitions to subscribe to.
   private KafkaSubscriber subscriber;
   // Users can specify the starting / stopping offset initializer.
@@ -209,6 +214,7 @@ public class LogKafkaSourceBuilder {
   public LogKafkaSourceBuilder setStartingOffsets(
       OffsetsInitializer startingOffsetsInitializer) {
     this.startingOffsetsInitializer = startingOffsetsInitializer;
+    LOG.info("Setting LogKafkaSource starting offset: {}", startingOffsetsInitializer);
     return this;
   }
 
@@ -413,13 +419,6 @@ public class LogKafkaSourceBuilder {
   private void setupStartupMode() {
     String startupMode = CompatiblePropertyUtil.propertyAsString(tableProperties, SCAN_STARTUP_MODE.key(),
         SCAN_STARTUP_MODE.defaultValue()).toLowerCase();
-    long startupTimestampMillis = 0L;
-    if (Objects.equals(startupMode.toLowerCase(), SCAN_STARTUP_MODE_TIMESTAMP)) {
-      startupTimestampMillis = Long.parseLong(Preconditions.checkNotNull(
-          tableProperties.get(SCAN_STARTUP_TIMESTAMP_MILLIS.key()),
-          String.format("'%s' should be set in '%s' mode",
-              SCAN_STARTUP_TIMESTAMP_MILLIS.key(), SCAN_STARTUP_MODE_TIMESTAMP)));
-    }
 
     switch (startupMode) {
       case SCAN_STARTUP_MODE_EARLIEST:
@@ -429,12 +428,39 @@ public class LogKafkaSourceBuilder {
         setStartingOffsets(OffsetsInitializer.latest());
         break;
       case SCAN_STARTUP_MODE_TIMESTAMP:
+        long startupTimestampMillis = Long.parseLong(Preconditions.checkNotNull(
+            tableProperties.get(SCAN_STARTUP_TIMESTAMP_MILLIS.key()),
+            String.format("'%s' should be set in '%s' mode",
+            SCAN_STARTUP_TIMESTAMP_MILLIS.key(), SCAN_STARTUP_MODE_TIMESTAMP)));
         setStartingOffsets(OffsetsInitializer.timestamp(startupTimestampMillis));
+        break;
+      case SCAN_STARTUP_MODE_GROUP_OFFSETS:
+        setStartingOffsets(OffsetsInitializer.committedOffsets());
+        break;
+      case SCAN_STARTUP_MODE_SPECIFIC_OFFSETS:
+        Map<TopicPartition, Long> specificOffsets = new HashMap<>();
+        String specificOffsetsStrOpt = Preconditions.checkNotNull(
+            tableProperties.get(SCAN_STARTUP_SPECIFIC_OFFSETS.key()),
+            String.format("'%s' should be set in '%s' mode",
+            SCAN_STARTUP_SPECIFIC_OFFSETS.key(), SCAN_STARTUP_MODE_SPECIFIC_OFFSETS));
+        final Map<Integer, Long> offsetMap =
+            parseSpecificOffsets(specificOffsetsStrOpt, SCAN_STARTUP_SPECIFIC_OFFSETS.key());
+        offsetMap.forEach(
+            (partition, offset) -> {
+            final TopicPartition topicPartition =
+                new TopicPartition(getLogTopic(tableProperties).get(0), partition);
+            specificOffsets.put(topicPartition, offset);
+          }
+        );
+        setStartingOffsets(OffsetsInitializer.offsets(specificOffsets));
         break;
       default:
         throw new ValidationException(String.format(
-            "%s only support '%s', '%s', '%s'. But input is '%s'", ArcticValidator.SCAN_STARTUP_MODE,
-            SCAN_STARTUP_MODE_LATEST, SCAN_STARTUP_MODE_EARLIEST, SCAN_STARTUP_MODE_TIMESTAMP, startupMode));
+          "%s only support '%s', '%s', '%s', '%s', '%s'. But input is '%s'",
+          ArcticValidator.SCAN_STARTUP_MODE,
+          SCAN_STARTUP_MODE_LATEST, SCAN_STARTUP_MODE_EARLIEST,
+          SCAN_STARTUP_MODE_TIMESTAMP, SCAN_STARTUP_MODE_GROUP_OFFSETS,
+          SCAN_STARTUP_MODE_SPECIFIC_OFFSETS, startupMode));
     }
   }
 
@@ -506,5 +532,44 @@ public class LogKafkaSourceBuilder {
     checkNotNull(
         subscriber,
         String.format("No topic is specified, '%s' should be set.", LOG_STORE_MESSAGE_TOPIC));
+  }
+
+  public static Map<Integer, Long> parseSpecificOffsets(
+      String specificOffsetsStr, String optionKey) {
+    final Map<Integer, Long> offsetMap = new HashMap<>();
+    final String[] pairs = specificOffsetsStr.split(";");
+    final String validationExceptionMessage =
+        String.format(
+        "Invalid properties '%s' should follow the format " +
+          "'partition:0,offset:42;partition:1,offset:300', but is '%s'.",
+        optionKey, specificOffsetsStr);
+
+    if (pairs.length == 0) {
+      throw new ValidationException(validationExceptionMessage);
+    }
+
+    for (String pair : pairs) {
+      if (null == pair || pair.length() == 0 || !pair.contains(",")) {
+        throw new ValidationException(validationExceptionMessage);
+      }
+
+      final String[] kv = pair.split(",");
+      if (kv.length != 2 ||
+          !kv[0].startsWith(PARTITION + ':') ||
+          !kv[1].startsWith(OFFSET + ':')) {
+        throw new ValidationException(validationExceptionMessage);
+      }
+
+      String partitionValue = kv[0].substring(kv[0].indexOf(":") + 1);
+      String offsetValue = kv[1].substring(kv[1].indexOf(":") + 1);
+      try {
+        final Integer partition = Integer.valueOf(partitionValue);
+        final Long offset = Long.valueOf(offsetValue);
+        offsetMap.put(partition, offset);
+      } catch (NumberFormatException e) {
+        throw new ValidationException(validationExceptionMessage, e);
+      }
+    }
+    return offsetMap;
   }
 }

--- a/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/descriptors/ArcticValidator.java
+++ b/flink/v1.14/flink/src/main/java/com/netease/arctic/flink/table/descriptors/ArcticValidator.java
@@ -78,6 +78,8 @@ public class ArcticValidator extends ConnectorDescriptorValidator {
   public static final String SCAN_STARTUP_MODE_EARLIEST = "earliest";
   public static final String SCAN_STARTUP_MODE_LATEST = "latest";
   public static final String SCAN_STARTUP_MODE_TIMESTAMP = "timestamp";
+  public static final String SCAN_STARTUP_MODE_GROUP_OFFSETS = "group-offsets";
+  public static final String SCAN_STARTUP_MODE_SPECIFIC_OFFSETS = "specific-offsets";
 
   public static final ConfigOption<Boolean> ARCTIC_LOG_CONSISTENCY_GUARANTEE_ENABLE =
       ConfigOptions.key("log-store.consistency-guarantee.enabled")
@@ -121,11 +123,11 @@ public class ArcticValidator extends ConnectorDescriptorValidator {
       .defaultValue(2048)
       .withDescription("The target number of records for Iceberg reader fetch batch.");
 
-  public static final ConfigOption<String> SCAN_STARTUP_MODE = ConfigOptions
-      .key("scan.startup.mode")
-      .stringType()
-      .defaultValue(SCAN_STARTUP_MODE_LATEST)
-      .withDescription(String.format("Optional startup mode for arctic source, valid values are " +
+  public static final ConfigOption<String> SCAN_STARTUP_MODE =
+      ConfigOptions.key("scan.startup.mode")
+          .stringType()
+          .defaultValue(SCAN_STARTUP_MODE_LATEST)
+          .withDescription(String.format("Optional startup mode for arctic source, valid values are " +
               "\"earliest\" or \"latest\", \"timestamp\". If %s values %s, \"earliest\":" +
               " read earliest table data including base and change files from" +
               " the current snapshot, \"latest\": read all incremental data in the change table starting from the" +
@@ -133,7 +135,7 @@ public class ArcticValidator extends ConnectorDescriptorValidator {
               " If %s values %s, \"earliest\": start from the earliest offset possible." +
               " \"latest\": start from the latest offset," +
               " \"timestamp\": start from user-supplied timestamp for each partition.",
-          ARCTIC_READ_MODE, ARCTIC_READ_FILE, ARCTIC_READ_MODE, ARCTIC_READ_LOG));
+              ARCTIC_READ_MODE, ARCTIC_READ_FILE, ARCTIC_READ_MODE, ARCTIC_READ_LOG));
 
   public static final ConfigOption<Long> SCAN_STARTUP_TIMESTAMP_MILLIS =
       ConfigOptions.key("scan.startup.timestamp-millis")
@@ -141,6 +143,13 @@ public class ArcticValidator extends ConnectorDescriptorValidator {
           .noDefaultValue()
           .withDescription(
               "Optional timestamp used in case of \"timestamp\" startup mode");
+
+  public static final ConfigOption<String> SCAN_STARTUP_SPECIFIC_OFFSETS =
+      ConfigOptions.key("scan.startup.specific-offsets")
+        .stringType()
+        .noDefaultValue()
+        .withDescription(
+            "Optional timestamp used in case of \"timestamp\" startup mode");
 
   public static final ConfigOption<Boolean> SUBMIT_EMPTY_SNAPSHOTS = ConfigOptions
       .key("submit.empty.snapshots")

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSourceBuilder.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/read/source/log/kafka/LogKafkaSourceBuilder.java
@@ -40,9 +40,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Properties;
 import java.util.Random;
 import java.util.Set;
@@ -50,8 +50,11 @@ import java.util.regex.Pattern;
 
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE_EARLIEST;
+import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE_GROUP_OFFSETS;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE_LATEST;
+import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE_SPECIFIC_OFFSETS;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_MODE_TIMESTAMP;
+import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_SPECIFIC_OFFSETS;
 import static com.netease.arctic.flink.table.descriptors.ArcticValidator.SCAN_STARTUP_TIMESTAMP_MILLIS;
 import static com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil.fetchLogstorePrefixProperties;
 import static com.netease.arctic.flink.util.CompatibleFlinkPropertyUtil.getLogTopic;
@@ -77,6 +80,8 @@ public class LogKafkaSourceBuilder {
   private static final String[] REQUIRED_CONFIGS = {
       ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, ConsumerConfig.GROUP_ID_CONFIG
   };
+  private static final String PARTITION = "partition";
+  private static final String OFFSET = "offset";
   // The subscriber specifies the partitions to subscribe to.
   private KafkaSubscriber subscriber;
   // Users can specify the starting / stopping offset initializer.
@@ -209,6 +214,7 @@ public class LogKafkaSourceBuilder {
   public LogKafkaSourceBuilder setStartingOffsets(
       OffsetsInitializer startingOffsetsInitializer) {
     this.startingOffsetsInitializer = startingOffsetsInitializer;
+    LOG.info("Setting LogKafkaSource starting offset: {}", startingOffsetsInitializer);
     return this;
   }
 
@@ -413,13 +419,6 @@ public class LogKafkaSourceBuilder {
   private void setupStartupMode() {
     String startupMode = CompatiblePropertyUtil.propertyAsString(tableProperties, SCAN_STARTUP_MODE.key(),
         SCAN_STARTUP_MODE.defaultValue()).toLowerCase();
-    long startupTimestampMillis = 0L;
-    if (Objects.equals(startupMode.toLowerCase(), SCAN_STARTUP_MODE_TIMESTAMP)) {
-      startupTimestampMillis = Long.parseLong(Preconditions.checkNotNull(
-          tableProperties.get(SCAN_STARTUP_TIMESTAMP_MILLIS.key()),
-          String.format("'%s' should be set in '%s' mode",
-              SCAN_STARTUP_TIMESTAMP_MILLIS.key(), SCAN_STARTUP_MODE_TIMESTAMP)));
-    }
 
     switch (startupMode) {
       case SCAN_STARTUP_MODE_EARLIEST:
@@ -429,12 +428,39 @@ public class LogKafkaSourceBuilder {
         setStartingOffsets(OffsetsInitializer.latest());
         break;
       case SCAN_STARTUP_MODE_TIMESTAMP:
+        long startupTimestampMillis = Long.parseLong(Preconditions.checkNotNull(
+            tableProperties.get(SCAN_STARTUP_TIMESTAMP_MILLIS.key()),
+            String.format("'%s' should be set in '%s' mode",
+            SCAN_STARTUP_TIMESTAMP_MILLIS.key(), SCAN_STARTUP_MODE_TIMESTAMP)));
         setStartingOffsets(OffsetsInitializer.timestamp(startupTimestampMillis));
+        break;
+      case SCAN_STARTUP_MODE_GROUP_OFFSETS:
+        setStartingOffsets(OffsetsInitializer.committedOffsets());
+        break;
+      case SCAN_STARTUP_MODE_SPECIFIC_OFFSETS:
+        Map<TopicPartition, Long> specificOffsets = new HashMap<>();
+        String specificOffsetsStrOpt = Preconditions.checkNotNull(
+            tableProperties.get(SCAN_STARTUP_SPECIFIC_OFFSETS.key()),
+            String.format("'%s' should be set in '%s' mode",
+            SCAN_STARTUP_SPECIFIC_OFFSETS.key(), SCAN_STARTUP_MODE_SPECIFIC_OFFSETS));
+        final Map<Integer, Long> offsetMap =
+            parseSpecificOffsets(specificOffsetsStrOpt, SCAN_STARTUP_SPECIFIC_OFFSETS.key());
+        offsetMap.forEach(
+            (partition, offset) -> {
+            final TopicPartition topicPartition =
+                new TopicPartition(getLogTopic(tableProperties).get(0), partition);
+            specificOffsets.put(topicPartition, offset);
+          }
+        );
+        setStartingOffsets(OffsetsInitializer.offsets(specificOffsets));
         break;
       default:
         throw new ValidationException(String.format(
-            "%s only support '%s', '%s', '%s'. But input is '%s'", ArcticValidator.SCAN_STARTUP_MODE,
-            SCAN_STARTUP_MODE_LATEST, SCAN_STARTUP_MODE_EARLIEST, SCAN_STARTUP_MODE_TIMESTAMP, startupMode));
+          "%s only support '%s', '%s', '%s', '%s', '%s'. But input is '%s'",
+          ArcticValidator.SCAN_STARTUP_MODE,
+          SCAN_STARTUP_MODE_LATEST, SCAN_STARTUP_MODE_EARLIEST,
+          SCAN_STARTUP_MODE_TIMESTAMP, SCAN_STARTUP_MODE_GROUP_OFFSETS,
+          SCAN_STARTUP_MODE_SPECIFIC_OFFSETS, startupMode));
     }
   }
 
@@ -506,5 +532,44 @@ public class LogKafkaSourceBuilder {
     checkNotNull(
         subscriber,
         String.format("No topic is specified, '%s' should be set.", LOG_STORE_MESSAGE_TOPIC));
+  }
+
+  public static Map<Integer, Long> parseSpecificOffsets(
+      String specificOffsetsStr, String optionKey) {
+    final Map<Integer, Long> offsetMap = new HashMap<>();
+    final String[] pairs = specificOffsetsStr.split(";");
+    final String validationExceptionMessage =
+        String.format(
+        "Invalid properties '%s' should follow the format " +
+          "'partition:0,offset:42;partition:1,offset:300', but is '%s'.",
+        optionKey, specificOffsetsStr);
+
+    if (pairs.length == 0) {
+      throw new ValidationException(validationExceptionMessage);
+    }
+
+    for (String pair : pairs) {
+      if (null == pair || pair.length() == 0 || !pair.contains(",")) {
+        throw new ValidationException(validationExceptionMessage);
+      }
+
+      final String[] kv = pair.split(",");
+      if (kv.length != 2 ||
+          !kv[0].startsWith(PARTITION + ':') ||
+          !kv[1].startsWith(OFFSET + ':')) {
+        throw new ValidationException(validationExceptionMessage);
+      }
+
+      String partitionValue = kv[0].substring(kv[0].indexOf(":") + 1);
+      String offsetValue = kv[1].substring(kv[1].indexOf(":") + 1);
+      try {
+        final Integer partition = Integer.valueOf(partitionValue);
+        final Long offset = Long.valueOf(offsetValue);
+        offsetMap.put(partition, offset);
+      } catch (NumberFormatException e) {
+        throw new ValidationException(validationExceptionMessage, e);
+      }
+    }
+    return offsetMap;
   }
 }

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/descriptors/ArcticValidator.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/table/descriptors/ArcticValidator.java
@@ -78,6 +78,8 @@ public class ArcticValidator extends ConnectorDescriptorValidator {
   public static final String SCAN_STARTUP_MODE_EARLIEST = "earliest";
   public static final String SCAN_STARTUP_MODE_LATEST = "latest";
   public static final String SCAN_STARTUP_MODE_TIMESTAMP = "timestamp";
+  public static final String SCAN_STARTUP_MODE_GROUP_OFFSETS = "group-offsets";
+  public static final String SCAN_STARTUP_MODE_SPECIFIC_OFFSETS = "specific-offsets";
 
   public static final ConfigOption<Boolean> ARCTIC_LOG_CONSISTENCY_GUARANTEE_ENABLE =
       ConfigOptions.key("log-store.consistency-guarantee.enabled")
@@ -138,6 +140,13 @@ public class ArcticValidator extends ConnectorDescriptorValidator {
   public static final ConfigOption<Long> SCAN_STARTUP_TIMESTAMP_MILLIS =
       ConfigOptions.key("scan.startup.timestamp-millis")
           .longType()
+          .noDefaultValue()
+          .withDescription(
+              "Optional timestamp used in case of \"timestamp\" startup mode");
+
+  public static final ConfigOption<String> SCAN_STARTUP_SPECIFIC_OFFSETS =
+      ConfigOptions.key("scan.startup.specific-offsets")
+          .stringType()
           .noDefaultValue()
           .withDescription(
               "Optional timestamp used in case of \"timestamp\" startup mode");


### PR DESCRIPTION
## Why are the changes needed?
cherry-pick from #1932 

## Brief change log
- set startingOffsets by different startup mode.

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / **no**)
- If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
