### PR TITLE
[AMORO-1962][helm-chart] Amoro Support Overwrite JVM Optional

### DIFF
--- a/charts/amoro/templates/amoro-configmap.yaml
+++ b/charts/amoro/templates/amoro-configmap.yaml
@@ -22,6 +22,11 @@ metadata:
   labels:
     {{- include "amoro.labels" . | nindent 4 }}
 data:
+  {{- with .Values.amoroConf.amoroEnv }}
+  config.sh: |
+    #!/usr/bin/env bash
+    {{- tpl . $ | nindent 4 }}
+  {{- end }}
   ## Helm chart provided Amoro configurations
   config.yaml: |
     ams:

--- a/charts/amoro/templates/amoro-deployment.yaml
+++ b/charts/amoro/templates/amoro-deployment.yaml
@@ -92,6 +92,14 @@ spec:
                 {{- tpl (toYaml .) $ | nindent 12 }}
               {{- end }}
             {{- end }}
+            {{- if or .Values.amoroConf.amoroEnv }}
+              mountPath: {{ .Values.amoroDir }}/amoro-{{ .Chart.AppVersion }}/bin/config.sh
+              readOnly: true
+              subPath: "config.sh"
+              {{- with .Values.volumeMounts }}
+                {{- tpl (toYaml .) $ | nindent 12 }}
+              {{- end }}
+            {{- end }}
           {{- with .Values.containers }}
             {{- tpl (toYaml .) $ | nindent 8 }}
           {{- end }}

--- a/charts/amoro/values.yaml
+++ b/charts/amoro/values.yaml
@@ -75,6 +75,14 @@ server:
 amoroDir: "/usr/local/ams"
 # AMS configurations files
 amoroConf:
+  # ams config.sh set env
+  amoroEnv: ~
+#  amoroEnv: |
+#    XMX_CONFIG="8196"
+#    XMS_CONFIG="8196"
+#    JMX_REMOTE_PORT_CONFIG=""
+#    JVM_EXTRA_CONFIG="-XX:NewRatio=1 -XX:SurvivorRatio=3"
+#    LANG_CONFIG="en_US.UTF-8"
   # ams database properties,default is derby. If production,suggest use mysql
   database:
     type: derby


### PR DESCRIPTION
## Why are the changes needed?

Amoro Helm Chart Support Overwrite JVM Optional.Users can adjust jvm and some other parameters

Close #1962 .

## Brief change log

Amoro Support Overwrite JVM Optional

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible
- [ ] Add screenshots for manual tests if appropriate
- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes)
- If yes, how is the feature documented? (not documented)
