### PR TITLE
[AMORO-1120] we return bytes array when we response file load request

### DIFF
--- a/ams/server/src/main/java/com/netease/arctic/server/dashboard/PlatformFileManager.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/dashboard/PlatformFileManager.java
@@ -27,8 +27,8 @@ public class PlatformFileManager extends PersistentBase {
   /**
    * getRuntime file content
    */
-  public String getFileContentById(Integer fileId) {
+  public byte[] getFileContentById(Integer fileId) {
     String fileContent = getAs(PlatformFileMapper.class, e -> e.getFileById(fileId));
-    return new String(Base64.getDecoder().decode(fileContent));
+    return Base64.getDecoder().decode(fileContent);
   }
 }

--- a/ams/server/src/main/java/com/netease/arctic/server/dashboard/controller/CatalogController.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/dashboard/controller/CatalogController.java
@@ -391,11 +391,11 @@ public class CatalogController {
     if (CONFIG_TYPE_STORAGE.equalsIgnoreCase(confType)) {
       Map<String, String> storageConfig = catalogMeta.getStorageConfigs();
       String key = configKey.replaceAll("-", "\\.");
-      ctx.result(new String(Base64.getDecoder().decode(storageConfig.get(key))));
+      ctx.result(Base64.getDecoder().decode(storageConfig.get(key)));
     } else if (CONFIG_TYPE_AUTH.equalsIgnoreCase(confType)) {
       Map<String, String> storageConfig = catalogMeta.getAuthConfigs();
       String key = configKey.replaceAll("-", "\\.");
-      ctx.result(new String(Base64.getDecoder().decode(storageConfig.get(key))));
+      ctx.result(Base64.getDecoder().decode(storageConfig.get(key)));
     } else {
       throw new RuntimeException("Invalid request for " + confType);
     }

--- a/ams/server/src/main/java/com/netease/arctic/server/dashboard/controller/PlatformFileInfoController.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/dashboard/controller/PlatformFileInfoController.java
@@ -65,7 +65,7 @@ public class PlatformFileInfoController {
   public void downloadFile(Context ctx) {
     String fileId = ctx.pathParam("fileId");
     Preconditions.checkArgument(StringUtils.isNumeric(fileId), "Invalid file id");
-    String content = platformFileInfoService.getFileContentById(Integer.valueOf(fileId));
+    byte[] content = platformFileInfoService.getFileContentById(Integer.valueOf(fileId));
     ctx.result(content);
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.netease.com/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?

Close #1120  cherry-pick #1379 to master.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- When receiving a file access request, return a byte array.


## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / **no**)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
