### PR TITLE
[AMORO-1945]AMS Support Database Secret On K8S

### DIFF
--- a/ams/server/src/main/java/com/netease/arctic/server/ArcticServiceContainer.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/ArcticServiceContainer.java
@@ -20,6 +20,7 @@ package com.netease.arctic.server;
 
 import com.alibaba.fastjson.JSONArray;
 import com.alibaba.fastjson.JSONObject;
+import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.netease.arctic.ams.api.ArcticTableMetastore;
 import com.netease.arctic.ams.api.Constants;
@@ -41,13 +42,13 @@ import com.netease.arctic.server.table.TableService;
 import com.netease.arctic.server.table.executor.AsyncTableExecutors;
 import com.netease.arctic.server.terminal.TerminalManager;
 import com.netease.arctic.server.utils.ConfigOption;
+import com.netease.arctic.server.utils.ConfigurationUtil;
 import com.netease.arctic.server.utils.Configurations;
 import com.netease.arctic.server.utils.ThriftServiceProxy;
 import io.javalin.Javalin;
 import io.javalin.http.HttpCode;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
-import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.thrift.TMultiplexedProcessor;
 import org.apache.thrift.TProcessor;
 import org.apache.thrift.protocol.TBinaryProtocol;
@@ -301,12 +302,13 @@ public class ArcticServiceContainer {
     private JSONObject yamlConfig;
 
     public void init() throws IOException {
-      initServiceConfig();
+      Map<String, Object> envConfig = initEnvConfig();
+      initServiceConfig(envConfig);
       initContainerConfig();
     }
 
     @SuppressWarnings("unchecked")
-    private void initServiceConfig() throws IOException {
+    private void initServiceConfig(Map<String, Object> envConfig) throws IOException {
       LOG.info("initializing service configuration...");
       String configPath = Environments.getConfigPath() + "/" + SERVER_CONFIG_FILENAME;
       LOG.info("load config from path: {}", configPath);
@@ -314,9 +316,17 @@ public class ArcticServiceContainer {
       JSONObject systemConfig = yamlConfig.getJSONObject(ArcticManagementConf.SYSTEM_CONFIG);
       Map<String, Object> expandedConfigurationMap = Maps.newHashMap();
       expandConfigMap(systemConfig, "", expandedConfigurationMap);
+      // If same configurations in files and environment variables, environment variables have higher priority.
+      expandedConfigurationMap.putAll(envConfig);
       validateConfig(expandedConfigurationMap);
       serviceConfig = Configurations.fromObjectMap(expandedConfigurationMap);
       SqlSessionFactoryProvider.getInstance().init(serviceConfig);
+    }
+
+    private Map<String, Object> initEnvConfig() {
+      LOG.info("initializing system env configuration...");
+      String prefix = ArcticManagementConf.SYSTEM_CONFIG.toUpperCase();
+      return ConfigurationUtil.convertConfigurationKeys(prefix, System.getenv());
     }
 
     private void validateConfig(Map<String, Object> systemConfig) {

--- a/ams/server/src/main/java/com/netease/arctic/server/utils/ConfigurationUtil.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/utils/ConfigurationUtil.java
@@ -150,6 +150,23 @@ public class ConfigurationUtil {
     }
   }
 
+  /**
+   * Convert System Env key to Configuration key
+   * For Example :
+   * AMS_DATABASE_PASSWORD ---> ams.database.password
+   * AMS_SERVER__EXPOSE__HOST ---> ams.server-expose-host
+   */
+  public static Map<String, Object> convertConfigurationKeys(String prefix, Map<String, String> values) {
+    return values.entrySet()
+        .stream()
+        .filter(entry -> entry.getKey().startsWith(prefix))
+        .collect(Collectors.toMap(
+            entry -> entry.getKey().replaceFirst(prefix + "_", "")
+                .toLowerCase().replaceAll("(_{2,})", "-").replace("_", "."),
+            Map.Entry::getValue
+        ));
+  }
+
   @SuppressWarnings("unchecked")
   public static <E extends Enum<?>> E convertToEnum(Object o, Class<E> clazz) {
     if (o.getClass().equals(clazz)) {

--- a/ams/server/src/test/java/com/netease/arctic/server/util/ConfigurationUtilTest.java
+++ b/ams/server/src/test/java/com/netease/arctic/server/util/ConfigurationUtilTest.java
@@ -1,0 +1,25 @@
+package com.netease.arctic.server.util;
+
+import com.netease.arctic.server.ArcticManagementConf;
+import com.netease.arctic.server.utils.ConfigurationUtil;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import static com.netease.arctic.server.ArcticManagementConf.DB_PASSWORD;
+import static com.netease.arctic.server.ArcticManagementConf.SERVER_EXPOSE_HOST;
+
+public class ConfigurationUtilTest {
+
+  @Test
+  public void testConvertConfigurationKeys() {
+    HashMap<String, String> dummyEnv = new HashMap<>(2);
+    String prefix = ArcticManagementConf.SYSTEM_CONFIG.toUpperCase();
+    dummyEnv.put("AMS_DATABASE_PASSWORD", "1234567");
+    dummyEnv.put("AMS_SERVER__EXPOSE__HOST", "127.0.0.1");
+    Map<String, Object> result = ConfigurationUtil.convertConfigurationKeys(prefix, dummyEnv);
+    Assert.assertNotNull("AMS_DATABASE_PASSWORD Convert Failed", result.get(DB_PASSWORD.key()));
+    Assert.assertNotNull("AMS_SERVER__EXPOSE__HOST Convert Failed", result.get(SERVER_EXPOSE_HOST.key()));
+  }
+}

--- a/charts/amoro/templates/amoro-configmap.yaml
+++ b/charts/amoro/templates/amoro-configmap.yaml
@@ -84,7 +84,6 @@ data:
         jdbc-driver-class: {{ .Values.amoroConf.database.driver | quote }}
         {{- if eq .Values.amoroConf.database.type "mysql" }}
         username: {{ .Values.amoroConf.database.username | quote }}
-        password: {{ .Values.amoroConf.database.password | quote }}
         {{- end }}
 
       #  MySQL database configuration.

--- a/charts/amoro/templates/amoro-database-secert.yaml
+++ b/charts/amoro/templates/amoro-database-secert.yaml
@@ -1,0 +1,30 @@
+{{/*
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
+
+{{- if eq .Values.amoroConf.database.type "mysql" }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app.kubernetes.io/name: amoro-database-secret
+        {{- include "amoro.labels" . | nindent 4 }}
+type: Opaque
+data:
+  # use helm set password
+  password: {{ .Values.amoroConf.database.password | b64enc | quote }}
+{{- end }}

--- a/charts/amoro/templates/amoro-deployment.yaml
+++ b/charts/amoro/templates/amoro-deployment.yaml
@@ -37,10 +37,16 @@ spec:
           args: {{- tpl (toYaml .) $ | nindent 12 }}
             {{- end }}
           env:
+            {{- if eq .Values.amoroConf.database.type "mysql" }}
+            - name: "AMS_DATABASE_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}
+                  key: password
+            {{- end }}
            {{- with .Values.env }}
            {{- tpl (toYaml .) $ | nindent 12 }}
             {{- end }}
-          envFrom:
            {{- with .Values.envFrom }}
           {{- tpl (toYaml .) $ | nindent 12 }}
           {{- end }}

--- a/charts/amoro/values.yaml
+++ b/charts/amoro/values.yaml
@@ -89,7 +89,7 @@ amoroConf:
     driver: org.apache.derby.jdbc.EmbeddedDriver
     url: jdbc:derby:/tmp/amoro/derby;create=true
   #    type: mysql
-  #    jdbc-driver-class: com.mysql.cj.jdbc.Driver
+  #    driver: com.mysql.cj.jdbc.Driver
   #    url: jdbc:mysql://127.0.0.1:3306/db?useUnicode=true&characterEncoding=UTF8&autoReconnect=true&useAffectedRows=true&useSSL=false
   #    username: admin
   #    password: admin


### PR DESCRIPTION
## Why are the changes needed?

AMS Helm Chart Support Database Secret On K8S
When the user fills in the mysql password in the helm template, use secret to protect it.

Close #1945 .

## Brief change log

- Add System Env Method Filter start with "ams.*" properties
- Database MySQL Type use secret to write env and read it

## How was this patch tested?

- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible
- [x] Add screenshots for manual tests if appropriate
- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes)
- If yes, how is the feature documented? (not documented)
