### PR TITLE
[AMORO-1935] Introduce a table property for task spliting size of self-optimizing

### DIFF
--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/OptimizingConfig.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/OptimizingConfig.java
@@ -252,8 +252,8 @@ public class OptimizingConfig {
   public int hashCode() {
     return Objects.hashCode(enabled, targetQuota, optimizerGroup, maxExecuteRetryCount, maxCommitRetryCount, targetSize,
         maxTaskSize, maxFileCount, openFileCost, fragmentRatio, minorLeastFileCount, minorLeastInterval,
-        majorDuplicateRatio,
-        fullTriggerInterval, fullRewriteAllFiles, baseHashBucket, baseRefreshInterval, hiveRefreshInterval);
+        majorDuplicateRatio, fullTriggerInterval, fullRewriteAllFiles, baseHashBucket, baseRefreshInterval,
+        hiveRefreshInterval);
   }
 
   @Override

--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/OptimizingConfig.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/OptimizingConfig.java
@@ -31,6 +31,9 @@ public class OptimizingConfig {
   //self-optimizing.target-size
   private long targetSize;
 
+  //self-optimizing.max-task-size-bytes
+  private long maxTaskSize;
+
   //self-optimizing.max-file-count
   private int maxFileCount;
 
@@ -109,6 +112,15 @@ public class OptimizingConfig {
 
   public OptimizingConfig setTargetSize(long targetSize) {
     this.targetSize = targetSize;
+    return this;
+  }
+
+  public long getMaxTaskSize() {
+    return maxTaskSize;
+  }
+
+  public OptimizingConfig setMaxTaskSize(long maxTaskSize) {
+    this.maxTaskSize = maxTaskSize;
     return this;
   }
 
@@ -226,9 +238,9 @@ public class OptimizingConfig {
     OptimizingConfig that = (OptimizingConfig) o;
     return enabled == that.enabled && Double.compare(that.targetQuota, targetQuota) == 0 &&
         maxExecuteRetryCount == that.maxExecuteRetryCount && maxCommitRetryCount == that.maxCommitRetryCount &&
-        targetSize == that.targetSize && maxFileCount == that.maxFileCount && openFileCost == that.openFileCost &&
-        fragmentRatio == that.fragmentRatio && minorLeastFileCount == that.minorLeastFileCount &&
-        minorLeastInterval == that.minorLeastInterval &&
+        targetSize == that.targetSize && maxTaskSize == that.maxTaskSize && maxFileCount == that.maxFileCount &&
+        openFileCost == that.openFileCost && fragmentRatio == that.fragmentRatio &&
+        minorLeastFileCount == that.minorLeastFileCount && minorLeastInterval == that.minorLeastInterval &&
         Double.compare(that.majorDuplicateRatio, majorDuplicateRatio) == 0 &&
         fullTriggerInterval == that.fullTriggerInterval && fullRewriteAllFiles == that.fullRewriteAllFiles &&
         baseHashBucket == that.baseHashBucket && baseRefreshInterval == that.baseRefreshInterval &&
@@ -239,7 +251,8 @@ public class OptimizingConfig {
   @Override
   public int hashCode() {
     return Objects.hashCode(enabled, targetQuota, optimizerGroup, maxExecuteRetryCount, maxCommitRetryCount, targetSize,
-        maxFileCount, openFileCost, fragmentRatio, minorLeastFileCount, minorLeastInterval, majorDuplicateRatio,
+        maxTaskSize, maxFileCount, openFileCost, fragmentRatio, minorLeastFileCount, minorLeastInterval,
+        majorDuplicateRatio,
         fullTriggerInterval, fullRewriteAllFiles, baseHashBucket, baseRefreshInterval, hiveRefreshInterval);
   }
 
@@ -252,6 +265,7 @@ public class OptimizingConfig {
         .add("maxExecuteRetryCount", maxExecuteRetryCount)
         .add("maxCommitRetryCount", maxCommitRetryCount)
         .add("targetSize", targetSize)
+        .add("maxTaskSize", maxTaskSize)
         .add("maxFileCount", maxFileCount)
         .add("openFileCost", openFileCost)
         .add("fragmentRatio", fragmentRatio)
@@ -295,6 +309,10 @@ public class OptimizingConfig {
             properties,
             TableProperties.SELF_OPTIMIZING_TARGET_SIZE,
             TableProperties.SELF_OPTIMIZING_TARGET_SIZE_DEFAULT))
+        .setMaxTaskSize(CompatiblePropertyUtil.propertyAsLong(
+            properties,
+            TableProperties.SELF_OPTIMIZING_MAX_TASK_SIZE,
+            TableProperties.SELF_OPTIMIZING_MAX_TASK_SIZE_DEFAULT))
         .setTargetQuota(CompatiblePropertyUtil.propertyAsDouble(
             properties,
             TableProperties.SELF_OPTIMIZING_QUOTA,

--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/AbstractPartitionPlan.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/AbstractPartitionPlan.java
@@ -289,7 +289,7 @@ public abstract class AbstractPartitionPlan implements PartitionEvaluator {
           allDataFiles.add(new FileTask(dataFile, deleteFiles, false)));
 
       List<List<FileTask>> packed = new BinPacking.ListPacker<FileTask>(
-          config.getTargetSize(), Integer.MAX_VALUE, false)
+          config.getMaxTaskSize(), Integer.MAX_VALUE, false)
           .pack(allDataFiles, f -> f.getFile().fileSizeInBytes());
 
       // collect

--- a/ams/server/src/main/java/com/netease/arctic/server/table/TableRuntime.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/table/TableRuntime.java
@@ -367,10 +367,6 @@ public class TableRuntime extends StatedPersistentBase {
     return optimizerGroup;
   }
 
-  public long getTargetSize() {
-    return tableConfiguration.getOptimizingConfig().getTargetSize();
-  }
-
   public void setCurrentChangeSnapshotId(long currentChangeSnapshotId) {
     this.currentChangeSnapshotId = currentChangeSnapshotId;
   }

--- a/core/src/main/java/com/netease/arctic/table/TableProperties.java
+++ b/core/src/main/java/com/netease/arctic/table/TableProperties.java
@@ -87,8 +87,8 @@ public class TableProperties {
   public static final String SELF_OPTIMIZING_MAX_FILE_CNT = "self-optimizing.max-file-count";
   public static final int SELF_OPTIMIZING_MAX_FILE_CNT_DEFAULT = 10000;
 
-  public static final String SELF_OPTIMIZING_MAX_FILE_SIZE_BYTES = "self-optimizing.max-file-size-bytes";
-  public static final long SELF_OPTIMIZING_MAX_FILE_SIZE_BYTES_DEFAULT = 8589934592L; // 8 GB
+  public static final String SELF_OPTIMIZING_MAX_TASK_SIZE = "self-optimizing.max-task-size-bytes";
+  public static final long SELF_OPTIMIZING_MAX_TASK_SIZE_DEFAULT = 1073741824L; // 1 GB
 
   public static final String SELF_OPTIMIZING_FRAGMENT_RATIO = "self-optimizing.fragment-ratio";
   public static final int SELF_OPTIMIZING_FRAGMENT_RATIO_DEFAULT = 8;

--- a/docs/user-guides/configurations.md
+++ b/docs/user-guides/configurations.md
@@ -32,14 +32,16 @@ Self-optimizing configurations are applicable to both Iceberg Format and Mixed s
 | self-optimizing.enabled                             | true             | Enables Self-optimizing                                |
 | self-optimizing.group                               | default          | Optimizer group for Self-optimizing                                   |
 | self-optimizing.quota                               | 0.1              | Quota for Self-optimizing, indicating the CPU resource the table can take up                       |
-| self-optimizing.execute.num-retries                         | 5                | Number of retries after failure of Self-optimizing                       |
+| self-optimizing.execute.num-retries                 | 5                | Number of retries after failure of Self-optimizing                       |
 | self-optimizing.target-size                         | 134217728(128MB) | Target size for Self-optimizing                           |
 | self-optimizing.max-file-count                      | 10000            | Maximum number of files processed by a Self-optimizing process              |               |
+| self-optimizing.max-task-size-bytes                 | 1073741824(1GB)  | Maximum file size bytes in a single task for splitting tasks                |               |
 | self-optimizing.fragment-ratio                      | 8                | The fragment file size threshold. We could divide self-optimizing.target-size by this ratio to get the actual fragment file size           |
 | self-optimizing.minor.trigger.file-count            | 12               | The minimum numbers of fragment files to trigger minor optimizing   |
 | self-optimizing.minor.trigger.interval              | 3600000(1 hour)  | The time interval in milliseconds to trigger minor optimizing                         |
 | self-optimizing.major.trigger.duplicate-ratio       | 0.5              | The ratio of duplicate data of segment files to trigger major optimizing  |
 | self-optimizing.full.trigger.interval               | -1(closed)       | The time interval in milliseconds to trigger full optimizing
+| self-optimizing.full.rewrite-all-files              | true             | Whether full optimizing rewrites all files or skips files that do not need to be optimized |
 
 ## Data-cleaning configurations
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.netease.com/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close #1935.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- add a new table property `self-optimizing.max-task-size-bytes`
- modify the docs

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / **no**)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
