### PR TITLE
[AMORO-1977] Fix retry logic in ThriftClientPool

### DIFF
--- a/ams/api/src/main/java/com/netease/arctic/ams/api/client/AmsClientPools.java
+++ b/ams/api/src/main/java/com/netease/arctic/ams/api/client/AmsClientPools.java
@@ -14,8 +14,9 @@ import org.apache.thrift.protocol.TProtocol;
  */
 public class AmsClientPools {
 
-  private static final int CLIENT_POOL_MIN = 0;
-  private static final int CLIENT_POOL_MAX = 5;
+  private static final int CLIENT_POOL_MIN_IDLE = 0;
+  private static final int CLIENT_POOL_MAX_IDLE = 5;
+  private static final int CLIENT_POOL_MAX_WAIT_MS = 5000;
 
   private static final LoadingCache<String, ThriftClientPool<ArcticTableMetastore.Client>> CLIENT_POOLS
       = Caffeine.newBuilder()
@@ -32,8 +33,9 @@ public class AmsClientPools {
   private static ThriftClientPool<ArcticTableMetastore.Client> buildClientPool(String url) {
     PoolConfig poolConfig = new PoolConfig();
     poolConfig.setFailover(true);
-    poolConfig.setMinIdle(CLIENT_POOL_MIN);
-    poolConfig.setMaxIdle(CLIENT_POOL_MAX);
+    poolConfig.setMinIdle(CLIENT_POOL_MIN_IDLE);
+    poolConfig.setMaxIdle(CLIENT_POOL_MAX_IDLE);
+    poolConfig.setMaxWaitMillis(CLIENT_POOL_MAX_WAIT_MS);
     return new ThriftClientPool<>(
         url,
         s -> {

--- a/ams/api/src/main/java/com/netease/arctic/ams/api/client/ThriftClientPool.java
+++ b/ams/api/src/main/java/com/netease/arctic/ams/api/client/ThriftClientPool.java
@@ -214,8 +214,8 @@ public class ThriftClientPool<T extends org.apache.thrift.TServiceClient> {
             LOG.warn("maybe server is restarting, wait a while");
             Thread.sleep(retryInterval);
           }
+          pool.invalidateObject(client);
           pool.clear();
-          client = pool.borrowObject();
         } else {
           break;
         }


### PR DESCRIPTION
## Why are the changes needed?

Close #1977.

## Brief change log

- Invalidate the object when the client is disconnected.
- Cancel the second time to get the client.

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable)
