### PR TITLE
[AMORO-2032]: Spark3.2 version does not require the class ResolveProcedures

### DIFF
--- a/spark/v3.2/spark/src/main/scala/com/netease/arctic/spark/ArcticSparkExtensions.scala
+++ b/spark/v3.2/spark/src/main/scala/com/netease/arctic/spark/ArcticSparkExtensions.scala
@@ -48,7 +48,6 @@ class ArcticSparkExtensions extends (SparkSessionExtensions => Unit) {
     extensions.injectOptimizerRule { spark => RewriteUpdateArcticTable(spark) }
 
     // iceberg extensions
-    extensions.injectResolutionRule { spark => ResolveProcedures(spark) }
     extensions.injectResolutionRule { spark => ResolveMergeIntoTableReferences(spark) }
     extensions.injectResolutionRule { _ => CheckMergeIntoTableConditions }
     extensions.injectResolutionRule { _ => ProcedureArgumentCoercion }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.netease.com/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->
When using amoro spark-3.2-runtime-0.5.0.jar, an error was reported and the class ResolveProcedures could not be found. Through comparison, it was found that changing the class is no longer necessary. Simply remove the dependency of this class.
Close #2032 .

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

-

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? ( no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
