### PR TITLE
[AMORO-2044]Fix the issue of not being able to write time fields with large time value in mixed-hive format

### DIFF
--- a/hive/src/main/java/com/netease/arctic/hive/utils/TimeUtil.java
+++ b/hive/src/main/java/com/netease/arctic/hive/utils/TimeUtil.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.hive.utils;
+
+import java.time.Instant;
+
+public class TimeUtil {
+
+  public static final long MICROS_PER_SECOND = 1000_000L;
+
+  public static final long NANO_PER_MICRO = 1000L;
+
+  /**
+   * Returns the microseconds between two instants.
+   * If jdk version less than 18 there is a bug in calculating microsecond intervals between two times using methods
+   * like 'ChronoUnit.MICROS.between(start, end)', this method is used instead.
+   * see: <a href="https://bugs.openjdk.org/browse/JDK-8273369">...</a>
+   */
+  public static long microsBetween(Instant start, Instant end) {
+    long secsDiff = Math.subtractExact(end.getEpochSecond(), start.getEpochSecond());
+    long totalMicros = Math.multiplyExact(secsDiff, MICROS_PER_SECOND);
+    return Math.addExact(totalMicros, (end.getNano() - start.getNano()) / NANO_PER_MICRO);
+  }
+}

--- a/hive/src/main/java/org/apache/iceberg/parquet/AdaptHiveParquetConversions.java
+++ b/hive/src/main/java/org/apache/iceberg/parquet/AdaptHiveParquetConversions.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg.parquet;
 
+import com.netease.arctic.hive.utils.TimeUtil;
 import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
@@ -33,7 +34,6 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
-import java.time.temporal.ChronoUnit;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -103,7 +103,7 @@ class AdaptHiveParquetConversions {
           instant = instant.atZone(ZoneId.systemDefault()).toLocalDateTime().toInstant(
               ZoneOffset.UTC);
         }
-        return ChronoUnit.MICROS.between(EPOCH, instant);
+        return TimeUtil.microsBetween(EPOCH, instant);
       };
     }
 

--- a/hive/src/test/java/com/netease/arctic/hive/utils/TestTimeUtil.java
+++ b/hive/src/test/java/com/netease/arctic/hive/utils/TestTimeUtil.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.hive.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.time.Instant;
+
+public class TestTimeUtil {
+
+  @Test
+  public void testTimeOverflow() {
+    Instant min = Instant.parse("0000-01-01T00:00:00.000Z");
+    Instant max = Instant.parse("9999-12-31T23:59:59.999Z");
+    TimeUtil.microsBetween(min, max);
+  }
+
+  @Test
+  public void testTimeRight() {
+    Instant start = Instant.parse("2023-01-01T00:00:00.000Z");
+    Instant end = Instant.parse("2023-01-01T00:00:00.123Z");
+    Assert.assertEquals(123000L, TimeUtil.microsBetween(start, end));
+  }
+}


### PR DESCRIPTION
## Why are the changes needed?
Close #2044 

## Brief change log
- Add 'com.netease.arctic.hive.utils.TimeUtil#microsBetween' to Instead 'ChronoUnit.MICROS.between(instant,instant)'

## How was this patch tested?

- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
