### PR TITLE
[Improvement]: Change socpe of `amoro:spark`  to runtime in `ams/server` dependency.

### DIFF
--- a/ams/server/pom.xml
+++ b/ams/server/pom.xml
@@ -127,6 +127,7 @@
             <groupId>com.netease.amoro</groupId>
             <artifactId>amoro-spark-${terminal.spark.major.version}</artifactId>
             <version>${project.version}</version>
+            <scope>runtime</scope>
         </dependency>
 
         <dependency>

--- a/ams/server/src/main/java/com/netease/arctic/server/terminal/local/LocalSessionFactory.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/terminal/local/LocalSessionFactory.java
@@ -23,12 +23,10 @@ import com.netease.arctic.server.terminal.TerminalSession;
 import com.netease.arctic.server.terminal.TerminalSessionFactory;
 import com.netease.arctic.server.utils.ConfigOptions;
 import com.netease.arctic.server.utils.Configurations;
-import com.netease.arctic.spark.ArcticSparkExtensions;
 import com.netease.arctic.table.TableMetaStore;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
-import org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions;
 import org.apache.spark.SparkConf;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.internal.SQLConf;
@@ -62,7 +60,7 @@ public class LocalSessionFactory implements TerminalSessionFactory {
     initializeLogs.add("setup session, session factory: " + LocalSessionFactory.class.getName());
 
     Map<String, String> sparkConf = SparkContextUtil.getSparkConf(configuration);
-    sparkConf.put(com.netease.arctic.spark.SparkSQLProperties.REFRESH_CATALOG_BEFORE_USAGE, "true");
+    sparkConf.put(SparkContextUtil.MIXED_FORMAT_PROPERTY_REFRESH_BEFORE_USAGE, "true");
 
     Map<String, String> finallyConf = configuration.toMap();
     catalogs.stream()
@@ -106,8 +104,8 @@ public class LocalSessionFactory implements TerminalSessionFactory {
       sparkconf.set(SQLConf.PARTITION_OVERWRITE_MODE().key(), "dynamic");
       sparkconf.set("spark.executor.heartbeatInterval", "100s");
       sparkconf.set("spark.network.timeout", "200s");
-      sparkconf.set("spark.sql.extensions", ArcticSparkExtensions.class.getName() +
-          "," + IcebergSparkSessionExtensions.class.getName());
+      sparkconf.set("spark.sql.extensions", SparkContextUtil.MIXED_FORMAT_EXTENSION +
+          "," + SparkContextUtil.ICEBERG_EXTENSION);
 
       for (String key : this.conf.keySet()) {
         if (key.startsWith(SPARK_CONF_PREFIX)) {


### PR DESCRIPTION
 

## Why are the changes needed?

The future mixed-format related features should be plug-in based. In order to better organize the project structure, the AMS module should not directly depend on the code of MixedFormat. This PR will remove the hard-coded access to the spark module in the AMS module.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- Change socpe of `amoro:spark` to runtime in `ams/server` dependencies part.
- Using static final string instead of `Class.getName` 

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [X] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (no)
