### PR TITLE
[AMORO-1935] Change the default value of Self-Optimizing split task size to 128MB

### DIFF
--- a/core/src/main/java/com/netease/arctic/table/TableProperties.java
+++ b/core/src/main/java/com/netease/arctic/table/TableProperties.java
@@ -88,7 +88,7 @@ public class TableProperties {
   public static final int SELF_OPTIMIZING_MAX_FILE_CNT_DEFAULT = 10000;
 
   public static final String SELF_OPTIMIZING_MAX_TASK_SIZE = "self-optimizing.max-task-size-bytes";
-  public static final long SELF_OPTIMIZING_MAX_TASK_SIZE_DEFAULT = 1073741824L; // 1 GB
+  public static final long SELF_OPTIMIZING_MAX_TASK_SIZE_DEFAULT = 134217728; // 128 MB
 
   public static final String SELF_OPTIMIZING_FRAGMENT_RATIO = "self-optimizing.fragment-ratio";
   public static final int SELF_OPTIMIZING_FRAGMENT_RATIO_DEFAULT = 8;

--- a/docs/user-guides/configurations.md
+++ b/docs/user-guides/configurations.md
@@ -35,7 +35,7 @@ Self-optimizing configurations are applicable to both Iceberg Format and Mixed s
 | self-optimizing.execute.num-retries                 | 5                | Number of retries after failure of Self-optimizing                       |
 | self-optimizing.target-size                         | 134217728(128MB) | Target size for Self-optimizing                           |
 | self-optimizing.max-file-count                      | 10000            | Maximum number of files processed by a Self-optimizing process              |               |
-| self-optimizing.max-task-size-bytes                 | 1073741824(1GB)  | Maximum file size bytes in a single task for splitting tasks                |               |
+| self-optimizing.max-task-size-bytes                 | 134217728(128MB) | Maximum file size bytes in a single task for splitting tasks                |               |
 | self-optimizing.fragment-ratio                      | 8                | The fragment file size threshold. We could divide self-optimizing.target-size by this ratio to get the actual fragment file size           |
 | self-optimizing.minor.trigger.file-count            | 12               | The minimum numbers of fragment files to trigger minor optimizing   |
 | self-optimizing.minor.trigger.interval              | 3600000(1 hour)  | The time interval in milliseconds to trigger minor optimizing                         |


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.netease.com/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

fix #1935 .
Change the default split task size from 1G to 128MB to keep the same behavior as in version 0.5.0 and avoid unexpected OOM errors.


## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- change default value of self-optimizing.max-task-size-bytes to 128MB

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / **no**)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
