### PR TITLE
[AMORO-2091] 0.4.x resolve the optimzing exception for KeyedTable with Timestamp(without zone) column as Primary key

### DIFF
--- a/core/src/main/java/com/netease/arctic/io/reader/ArcticDeleteFilter.java
+++ b/core/src/main/java/com/netease/arctic/io/reader/ArcticDeleteFilter.java
@@ -144,7 +144,8 @@ public abstract class ArcticDeleteFilter<T> {
     deleteIds.add(MetadataColumns.FILE_OFFSET_FILED.fieldId());
     this.deleteSchema = TypeUtil.select(requiredSchema, deleteIds);
     if (sourceNodes != null) {
-      this.deleteNodeFilter = new NodeFilter<>(sourceNodes, deleteSchema, primaryKeySpec, record -> record);
+      this.deleteNodeFilter = new NodeFilter<>(sourceNodes, deleteSchema, primaryKeySpec,
+          record -> new InternalRecordWrapper(deleteSchema.asStruct()).wrap(record));
     } else {
       this.deleteNodeFilter = null;
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.netease.com/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close #2091 . fix in 0.4.x

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- NodeFilter should use InternalRecordWrapper to build PrimaryKeyData

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / **no**)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
