### PR TITLE
[AMORO-2091] Resolve the optimzing exception for KeyedTable with Timestamp(without zone) column as Primary key

### DIFF
--- a/core/src/main/java/com/netease/arctic/io/reader/ArcticDeleteFilter.java
+++ b/core/src/main/java/com/netease/arctic/io/reader/ArcticDeleteFilter.java
@@ -147,7 +147,8 @@ public abstract class ArcticDeleteFilter<T> {
         TypeUtil.select(requiredSchema, Sets.newHashSet(primaryKeyId)),
         new Schema(MetadataColumns.FILE_OFFSET_FILED, MetadataColumns.TRANSACTION_ID_FILED));
     if (CollectionUtils.isNotEmpty(sourceNodes)) {
-      this.deleteNodeFilter = new NodeFilter<>(sourceNodes, deleteSchema, primaryKeySpec, record -> record);
+      this.deleteNodeFilter = new NodeFilter<>(sourceNodes, deleteSchema, primaryKeySpec,
+          record -> new InternalRecordWrapper(deleteSchema.asStruct()).wrap(record));
     } else {
       this.deleteNodeFilter = null;
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.netease.com/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close #2091.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- [using InternalRecordWrapper to build PrimaryKeyData for NodeFilter](https://github.com/NetEase/amoro/commit/15b1bb68f179972f61ae892059d081cfa3054c2d)

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / **no**)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
