### PR TITLE
[AMORO-2109] Make AMS table sync with external catalogs multithreaded

### DIFF
--- a/ams/server/src/main/java/com/netease/arctic/server/ArcticManagementConf.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/ArcticManagementConf.java
@@ -103,6 +103,18 @@ public class ArcticManagementConf {
           .defaultValue(60000L)
           .withDescription("Interval for refreshing table metadata.");
 
+  public static final ConfigOption<Integer> EXTERNAL_CATALOGS_EXPLORER_THREAD_COUNT =
+          ConfigOptions.key("external-catalog-explorer.thread-count")
+                  .intType()
+                  .defaultValue(10)
+                  .withDescription("The number of threads used for discover tables in external catalogs.");
+
+  public static final ConfigOption<Integer> EXTERNAL_CATALOGS_EXPLORER_QUEUE_SIZE =
+          ConfigOptions.key("external-catalog-explorer.queue-size")
+                  .intType()
+                  .defaultValue(1000000)
+                  .withDescription("The queue size of the executors of the external catalog explorer.");
+
   public static final ConfigOption<Long> BLOCKER_TIMEOUT =
       ConfigOptions.key("blocker.timeout")
           .longType()

--- a/ams/server/src/main/java/com/netease/arctic/server/ArcticManagementConf.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/ArcticManagementConf.java
@@ -60,7 +60,7 @@ public class ArcticManagementConf {
       ConfigOptions.key("refresh-external-catalogs.thread-count")
           .intType()
           .defaultValue(10)
-          .withDescription("The number of threads used for discover tables in external catalogs.");
+          .withDescription("The number of threads used for discovering tables in external catalogs.");
 
   public static final ConfigOption<Integer> REFRESH_EXTERNAL_CATALOGS_QUEUE_SIZE =
       ConfigOptions.key("refresh-external-catalogs.queue-size")

--- a/ams/server/src/main/java/com/netease/arctic/server/ArcticManagementConf.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/ArcticManagementConf.java
@@ -21,6 +21,7 @@ package com.netease.arctic.server;
 
 import com.netease.arctic.server.utils.ConfigOption;
 import com.netease.arctic.server.utils.ConfigOptions;
+
 import java.time.Duration;
 
 public class ArcticManagementConf {
@@ -56,16 +57,16 @@ public class ArcticManagementConf {
           .withDescription("Interval to refresh the external catalog.");
 
   public static final ConfigOption<Integer> REFRESH_EXTERNAL_CATALOGS_THREAD_COUNT =
-          ConfigOptions.key("refresh-external-catalogs.thread-count")
-                  .intType()
-                  .defaultValue(10)
-                  .withDescription("The number of threads used for discover tables in external catalogs.");
+      ConfigOptions.key("refresh-external-catalogs.thread-count")
+          .intType()
+          .defaultValue(10)
+          .withDescription("The number of threads used for discover tables in external catalogs.");
 
   public static final ConfigOption<Integer> REFRESH_EXTERNAL_CATALOGS_QUEUE_SIZE =
-          ConfigOptions.key("refresh-external-catalogs.queue-size")
-                  .intType()
-                  .defaultValue(1000000)
-                  .withDescription("The queue size of the executors of the external catalog explorer.");
+      ConfigOptions.key("refresh-external-catalogs.queue-size")
+          .intType()
+          .defaultValue(1000000)
+          .withDescription("The queue size of the executors of the external catalog explorer.");
 
   public static final ConfigOption<Boolean> EXPIRE_SNAPSHOTS_ENABLED =
       ConfigOptions.key("expire-snapshots.enabled")

--- a/ams/server/src/main/java/com/netease/arctic/server/ArcticManagementConf.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/ArcticManagementConf.java
@@ -55,6 +55,18 @@ public class ArcticManagementConf {
           .defaultValue(3 * 60 * 1000L)
           .withDescription("Interval to refresh the external catalog.");
 
+  public static final ConfigOption<Integer> REFRESH_EXTERNAL_CATALOGS_THREAD_COUNT =
+          ConfigOptions.key("refresh-external-catalogs.thread-count")
+                  .intType()
+                  .defaultValue(10)
+                  .withDescription("The number of threads used for discover tables in external catalogs.");
+
+  public static final ConfigOption<Integer> REFRESH_EXTERNAL_CATALOGS_QUEUE_SIZE =
+          ConfigOptions.key("refresh-external-catalogs.queue-size")
+                  .intType()
+                  .defaultValue(1000000)
+                  .withDescription("The queue size of the executors of the external catalog explorer.");
+
   public static final ConfigOption<Boolean> EXPIRE_SNAPSHOTS_ENABLED =
       ConfigOptions.key("expire-snapshots.enabled")
           .booleanType()
@@ -102,18 +114,6 @@ public class ArcticManagementConf {
           .longType()
           .defaultValue(60000L)
           .withDescription("Interval for refreshing table metadata.");
-
-  public static final ConfigOption<Integer> EXTERNAL_CATALOGS_EXPLORER_THREAD_COUNT =
-          ConfigOptions.key("external-catalog-explorer.thread-count")
-                  .intType()
-                  .defaultValue(10)
-                  .withDescription("The number of threads used for discover tables in external catalogs.");
-
-  public static final ConfigOption<Integer> EXTERNAL_CATALOGS_EXPLORER_QUEUE_SIZE =
-          ConfigOptions.key("external-catalog-explorer.queue-size")
-                  .intType()
-                  .defaultValue(1000000)
-                  .withDescription("The queue size of the executors of the external catalog explorer.");
 
   public static final ConfigOption<Long> BLOCKER_TIMEOUT =
       ConfigOptions.key("blocker.timeout")

--- a/ams/server/src/main/java/com/netease/arctic/server/table/DefaultTableService.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/table/DefaultTableService.java
@@ -24,7 +24,6 @@ import com.netease.arctic.server.persistence.mapper.TableMetaMapper;
 import com.netease.arctic.server.table.blocker.TableBlocker;
 import com.netease.arctic.server.utils.Configurations;
 import org.apache.commons.lang.StringUtils;
-import org.apache.iceberg.exceptions.NoSuchIcebergTableException;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.slf4j.Logger;
@@ -434,13 +433,7 @@ public class DefaultTableService extends StatedPersistentBase implements TableSe
                               try {
                                 syncTable(externalCatalog, tableIdentity);
                               } catch (Exception e) {
-                                if (e.getCause() != null &&
-                                    e.getCause() instanceof NoSuchIcebergTableException &&
-                                    e.getMessage().contains("Not an iceberg table")) {
-                                  LOG.info("Skip non-iceberg table {}.", tableIdentity.toString());
-                                } else {
-                                  LOG.error("TableExplorer sync table {} error", tableIdentity.toString(), e);
-                                }
+                                LOG.error("TableExplorer sync table {} error", tableIdentity.toString(), e);
                               }
                             }, tableExplorerExecutors));
                   } catch (RejectedExecutionException e) {

--- a/ams/server/src/main/java/com/netease/arctic/server/table/DefaultTableService.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/table/DefaultTableService.java
@@ -327,8 +327,8 @@ public class DefaultTableService extends StatedPersistentBase implements TableSe
       headHandler.initialize(tableRuntimeMetaList);
     }
     if (tableExplorerExecutors == null) {
-      int threadCount = serverConfiguration.getInteger(ArcticManagementConf.EXTERNAL_CATALOGS_EXPLORER_THREAD_COUNT);
-      int queueSize = serverConfiguration.getInteger(ArcticManagementConf.EXTERNAL_CATALOGS_EXPLORER_QUEUE_SIZE);
+      int threadCount = serverConfiguration.getInteger(ArcticManagementConf.REFRESH_EXTERNAL_CATALOGS_THREAD_COUNT);
+      int queueSize = serverConfiguration.getInteger(ArcticManagementConf.REFRESH_EXTERNAL_CATALOGS_QUEUE_SIZE);
       tableExplorerExecutors = new ThreadPoolExecutor(
               threadCount,
               threadCount,

--- a/ams/server/src/main/java/com/netease/arctic/server/table/DefaultTableService.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/table/DefaultTableService.java
@@ -1,7 +1,9 @@
 package com.netease.arctic.server.table;
 
 import com.google.common.base.Objects;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.netease.arctic.AmoroTable;
 import com.netease.arctic.ams.api.BlockableOperation;
 import com.netease.arctic.ams.api.Blocker;
@@ -22,6 +24,7 @@ import com.netease.arctic.server.persistence.mapper.TableMetaMapper;
 import com.netease.arctic.server.table.blocker.TableBlocker;
 import com.netease.arctic.server.utils.Configurations;
 import org.apache.commons.lang.StringUtils;
+import org.apache.iceberg.exceptions.NoSuchIcebergTableException;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.slf4j.Logger;
@@ -31,10 +34,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.Timer;
-import java.util.TimerTask;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 public class DefaultTableService extends StatedPersistentBase implements TableService {
@@ -47,7 +55,15 @@ public class DefaultTableService extends StatedPersistentBase implements TableSe
   @StateField
   private final Map<ServerTableIdentifier, TableRuntime> tableRuntimeMap = new ConcurrentHashMap<>();
   private RuntimeHandlerChain headHandler;
-  private Timer tableExplorerTimer;
+
+  private final ScheduledExecutorService tableExplorerScheduler = Executors.newSingleThreadScheduledExecutor(
+            new ThreadFactoryBuilder()
+                    .setNameFormat("table-explorer-scheduler")
+                    .setDaemon(true)
+                    .build()
+  );
+
+  private ExecutorService tableExplorerExecutors;
 
   private final CompletableFuture<Boolean> initialized = new CompletableFuture<>();
   private final Configurations serverConfiguration;
@@ -310,11 +326,25 @@ public class DefaultTableService extends StatedPersistentBase implements TableSe
     if (headHandler != null) {
       headHandler.initialize(tableRuntimeMetaList);
     }
-    tableExplorerTimer = new Timer("ExternalTableExplorer", true);
-    tableExplorerTimer.scheduleAtFixedRate(
-        new TableExplorer(),
-        0,
-        externalCatalogRefreshingInterval);
+    if (tableExplorerExecutors == null) {
+      int threadCount = serverConfiguration.getInteger(ArcticManagementConf.EXTERNAL_CATALOGS_EXPLORER_THREAD_COUNT);
+      int queueSize = serverConfiguration.getInteger(ArcticManagementConf.EXTERNAL_CATALOGS_EXPLORER_QUEUE_SIZE);
+      tableExplorerExecutors = new ThreadPoolExecutor(
+              threadCount,
+              threadCount,
+              0,
+              TimeUnit.SECONDS,
+              new LinkedBlockingQueue<>(queueSize),
+              new ThreadFactoryBuilder()
+                      .setNameFormat("table-explorer-executor-%d")
+                      .setDaemon(true)
+                      .build());
+    }
+    tableExplorerScheduler.scheduleAtFixedRate(
+            this::exploreExternalCatalog,
+            0,
+            externalCatalogRefreshingInterval,
+            TimeUnit.MILLISECONDS);
     initialized.complete(true);
   }
 
@@ -348,8 +378,9 @@ public class DefaultTableService extends StatedPersistentBase implements TableSe
   }
 
   public void dispose() {
-    if (tableExplorerTimer != null) {
-      tableExplorerTimer.cancel();
+    tableExplorerScheduler.shutdown();
+    if (tableExplorerExecutors != null) {
+      tableExplorerExecutors.shutdown();
     }
     if (headHandler != null) {
       headHandler.dispose();
@@ -358,36 +389,82 @@ public class DefaultTableService extends StatedPersistentBase implements TableSe
 
   @VisibleForTesting
   void exploreExternalCatalog() {
+    long start = System.currentTimeMillis();
+    LOG.info("Syncing external catalogs: {}", String.join(",", externalCatalogMap.keySet()));
     for (ExternalCatalog externalCatalog : externalCatalogMap.values()) {
       try {
-        Set<TableIdentity> tableIdentifiers = externalCatalog.listTables().stream()
-            .map(TableIdentity::new)
-            .collect(Collectors.toSet());
+        final List<CompletableFuture<Set<TableIdentity>>> tableIdentifiersFuture = Lists.newArrayList();
+        externalCatalog.listDatabases().forEach(
+                database -> {
+                  try {
+                    tableIdentifiersFuture.add(
+                            CompletableFuture.supplyAsync(
+                                    () -> externalCatalog.listTables(database).stream()
+                                            .map(TableIdentity::new)
+                                            .collect(Collectors.toSet()), tableExplorerExecutors));
+                  } catch (RejectedExecutionException e) {
+                    LOG.error("The queue of table explorer is full, please increase the queue size or thread count.");
+                  }
+                }
+        );
+        Set<TableIdentity> tableIdentifiers =
+                tableIdentifiersFuture.stream()
+                        .map(CompletableFuture::join)
+                        .reduce(
+                                (a, b) -> {
+                                  a.addAll(b);
+                                  return a; })
+                        .orElse(Sets.newHashSet());
+        LOG.info("Loaded {} tables from external catalog {}.", tableIdentifiers.size(), externalCatalog.name());
         Map<TableIdentity, ServerTableIdentifier> serverTableIdentifiers =
             getAs(
                 TableMetaMapper.class,
                 mapper -> mapper.selectTableIdentifiersByCatalog(externalCatalog.name())).stream()
                 .collect(Collectors.toMap(TableIdentity::new, tableIdentifier -> tableIdentifier));
+        LOG.info("Loaded {} tables from Amoro server catalog {}.", serverTableIdentifiers.size(), externalCatalog. name());
         Sets.difference(tableIdentifiers, serverTableIdentifiers.keySet())
             .forEach(tableIdentity -> {
               try {
-                syncTable(externalCatalog, tableIdentity);
-              } catch (Exception e) {
-                LOG.error("TableExplorer sync table {} error", tableIdentity.toString(), e);
+                tableExplorerExecutors.submit(
+                        () -> {
+                          try {
+                            syncTable(externalCatalog, tableIdentity);
+                          } catch (Exception e) {
+                            if (e.getCause() != null &&
+                                    e.getCause() instanceof NoSuchIcebergTableException &&
+                                    e.getMessage().contains("Not an iceberg table")) {
+                              LOG.info("Skip non-iceberg table {}.", tableIdentity.toString());
+                            } else {
+                              LOG.error("TableExplorer sync table {} error", tableIdentity.toString(), e);
+                            }
+                          }
+                        });
+              } catch (RejectedExecutionException e) {
+                LOG.error("The queue of table explorer is full, please increase the queue size or thread count.");
               }
-            });
+            }
+            );
         Sets.difference(serverTableIdentifiers.keySet(), tableIdentifiers)
             .forEach(tableIdentity -> {
               try {
-                disposeTable(externalCatalog, serverTableIdentifiers.get(tableIdentity));
-              } catch (Exception e) {
-                LOG.error("TableExplorer dispose table {} error", tableIdentity.toString(), e);
+                tableExplorerExecutors.submit(
+                        () -> {
+                          try {
+                            disposeTable(externalCatalog, serverTableIdentifiers.get(tableIdentity));
+                          } catch (Exception e) {
+                            LOG.error("TableExplorer dispose table {} error", tableIdentity.toString(), e);
+                          }
+                        });
+              } catch (RejectedExecutionException e) {
+                LOG.error("The queue of table explorer is full, please increase the queue size or thread count.");
               }
             });
-      } catch (Exception e) {
-        LOG.error("TableExplorer run error", e);
+      } catch (Throwable e) {
+        LOG.error("TableExplorer error", e);
       }
     }
+    long end = System.currentTimeMillis();
+    LOG.info("Syncing external catalogs took {} ms.", end - start);
   }
 
   private void validateTableIdentifier(TableIdentifier tableIdentifier) {
@@ -436,19 +513,16 @@ public class DefaultTableService extends StatedPersistentBase implements TableSe
     }
   }
 
-  private class TableExplorer extends TimerTask {
-
-    @Override
-    public void run() {
-      exploreExternalCatalog();
-    }
-  }
-
   private void syncTable(ExternalCatalog externalCatalog, TableIdentity tableIdentity) {
-    invokeConsisitency(() -> doAsTransaction(
-        () -> externalCatalog.syncTable(tableIdentity.getDatabase(), tableIdentity.getTableName()),
-        () -> handleTableRuntimeAdded(externalCatalog, tableIdentity)
-    ));
+    try {
+      doAsTransaction(
+              () -> externalCatalog.syncTable(tableIdentity.getDatabase(), tableIdentity.getTableName()),
+              () -> handleTableRuntimeAdded(externalCatalog, tableIdentity)
+      );
+    } catch (Throwable t) {
+      revertTableRuntimeAdded(externalCatalog, tableIdentity);
+      throw t;
+    }
   }
 
   private void handleTableRuntimeAdded(ExternalCatalog externalCatalog, TableIdentity tableIdentity) {
@@ -461,6 +535,14 @@ public class DefaultTableService extends StatedPersistentBase implements TableSe
     tableRuntimeMap.put(tableIdentifier, tableRuntime);
     if (headHandler != null) {
       headHandler.fireTableAdded(table, tableRuntime);
+    }
+  }
+
+  private void revertTableRuntimeAdded(ExternalCatalog externalCatalog, TableIdentity tableIdentity) {
+    ServerTableIdentifier tableIdentifier =
+        externalCatalog.getServerTableIdentifier(tableIdentity.getDatabase(), tableIdentity.getTableName());
+    if (tableIdentifier != null) {
+      tableRuntimeMap.remove(tableIdentifier);
     }
   }
 

--- a/ams/server/src/main/java/com/netease/arctic/server/table/DefaultTableService.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/table/DefaultTableService.java
@@ -421,7 +421,8 @@ public class DefaultTableService extends StatedPersistentBase implements TableSe
                 TableMetaMapper.class,
                 mapper -> mapper.selectTableIdentifiersByCatalog(externalCatalog.name())).stream()
                 .collect(Collectors.toMap(TableIdentity::new, tableIdentifier -> tableIdentifier));
-        LOG.info("Loaded {} tables from Amoro server catalog {}.", serverTableIdentifiers.size(), externalCatalog. name());
+        LOG.info("Loaded {} tables from Amoro server catalog {}.",
+                serverTableIdentifiers.size(), externalCatalog. name());
         Sets.difference(tableIdentifiers, serverTableIdentifiers.keySet())
             .forEach(tableIdentity -> {
               try {

--- a/dist/src/main/arctic-bin/conf/config.yaml
+++ b/dist/src/main/arctic-bin/conf/config.yaml
@@ -19,6 +19,8 @@ ams:
 
   refresh-external-catalogs:
     interval: 180000 # 3min
+    thread-count: 10
+    queue-size: 1000000
 
   refresh-tables:
     thread-count: 10


### PR DESCRIPTION

## Why are the changes needed?

As titled.

Close #2109.

## Brief change log

- Remove the lock in the table sync.
- Delegate the table sync workload to a configurable thread pool.

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no) no
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) not documented
