### PR TITLE
[AMORO-1957] Support liveness port testing for standby instance

### DIFF
--- a/ams/server/src/main/java/com/netease/arctic/server/ArcticManagementConf.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/ArcticManagementConf.java
@@ -49,6 +49,12 @@ public class ArcticManagementConf {
           .defaultValue("admin")
           .withDescription("The administrator password");
 
+  public static final ConfigOption<Integer> LIVENESS_PROBE_TCP_PORT =
+      ConfigOptions.key("liveness-probe-tcp-port")
+          .intType()
+          .defaultValue(-1)
+          .withDescription("livenessProbe tcp port of the server.");
+
   public static final ConfigOption<Long> REFRESH_EXTERNAL_CATALOGS_INTERVAL =
       ConfigOptions.key("refresh-external-catalogs.interval")
           .longType()

--- a/dist/src/main/arctic-bin/conf/config.yaml
+++ b/dist/src/main/arctic-bin/conf/config.yaml
@@ -3,6 +3,7 @@ ams:
   admin-password: admin
   server-bind-host: "0.0.0.0"
   server-expose-host: "127.0.0.1"
+  liveness-probe-tcp-port: -1
 
   thrift-server:
     max-message-size: 104857600 # 100MB


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.netease.com/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close ##1957

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- Start a thread to open the port for k8s when the container starts k8s use for livenessprobe

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [X] Add screenshots for manual tests if appropriate

In my environment it works fine.

![image](https://github.com/NetEase/amoro/assets/40817998/c4d6bb88-57e6-43bc-bd89-d7de5c8b3eb7)

- [X] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not documented)
