### PR TITLE
[Workflow]: Auto build Official Docker Image

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -25,7 +25,6 @@ on:
   push:
     branches:
       - "master"
-      - "docker-image"
     tags:
       - "v*"
 

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -142,13 +142,13 @@ jobs:
           OPTIMIZER_FLINK=${{ matrix.flink }} && \
           echo "OPTIMIZER_FLINK=-Doptimizer.flink${OPTIMIZER_FLINK%.*}" >> $GITHUB_ENV
 
-      - name: Build optimizer module with Maven
-        run: mvn clean install -pl 'ams/optimizer/flink-optimizer' -am -e ${OPTIMIZER_FLINK} -DskipTests -B -ntp
-
       - name: Set ENV Amoro version
         run: |
-          AMORO_VERSION=`cat ./pom.xml | grep 'amoro-parent' -C 3 | grep -Eo '<version>.*</version>' | awk -F'[><]' '{print $3}'` \
+          AMORO_VERSION=`cat pom.xml | grep 'amoro-parent' -C 3 | grep -Eo '<version>.*</version>' | awk -F'[><]' '{print $3}'` \
           && echo "AMORO_VERSION=${AMORO_VERSION}" >> $GITHUB_ENV
+
+      - name: Build optimizer module with Maven
+        run: mvn clean install -pl 'ams/optimizer/flink-optimizer' -am -e ${OPTIMIZER_FLINK} -DskipTests -B -ntp
 
       - name: Build and Push Flink Optimizer Docker Image
         uses: docker/build-push-action@v4

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -152,8 +152,6 @@ jobs:
 
       - name: Build and Push Flink Optimizer Docker Image
         uses: docker/build-push-action@v4
-        env:
-          AMORO_VERSION=
         with:
           context: .
           push: true

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -176,7 +176,7 @@ jobs:
     name: Push Amoro Quick-Demo Docker Image to Docker Hub
     runs-on: ubuntu-latest
     needs: docker-amoro
-    if: ${{ startsWith(github.repository, 'NetEase/') }}
+    if: ${{ startsWith(github.repository, 'NetEase/') && starsWith(github.ref, 'refs/tags/' )}}
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 8

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -166,3 +166,56 @@ jobs:
           build-args: |
             FLINK_VERSION=${{ matrix.flink }}
             OPTIMIZER_JOB=ams/optimizer/flink-optimizer/target/flink-optimizer-${{ env.AMORO_VERSION }}-jar-with-dependencies.jar
+
+  docker-quickdemo:
+    name: Push Amoro Quick-Demo Docker Image to Docker Hub
+    runs-on: ubuntu-latest
+    needs: docker-amoro
+    if: ${{ startsWith(github.repository, 'NetEase/') }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+          cache: maven
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Set up Docker tags
+        uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: |
+            name=arctic163/quickdemo
+          tags: |
+            type=ref,event=branch,suffix=-snapshot
+            type=semver,pattern={{version}}
+
+      - name: Print tags
+        run: echo '${{ steps.meta.outputs.tags }}'
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build optimizer module with Maven
+        run: mvn clean package -pl 'flink/v.17/flink-runtime' -am -e -DskipTests -B -ntp
+
+      - name: Build and Push Flink Optimizer Docker Image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          file: docker/quickdemo/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          build-args: |
+            AMORO_TAG: ${{ steps.meta.outputs.tags }}
+            FLINK_VERSION: 1.17.1

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -59,12 +59,13 @@ jobs:
         id: meta
         with:
           images: |
-            arctic163/amoro
+            name=arctic163/amoro
           tags: |
-            type=ref,event=branch,enable=${{ matrix.hadoop == 'v3' }},value=master-snapshot
-            type=ref,event=branch,enable=${{ matrix.hadoop == 'v2' }},value=master-snapshot-hadoop2
-            type=semver,enable=${{ matrix.hadoop == 'v3' }},pattern={{version}}
-            type=semver,enable=${{ matrix.hadoop == 'v2' }},pattern={{version}}-hadoop2
+            type=ref,event=branch,enable=${{ matrix.hadoop == 'v3' }},suffix='-snapshot'
+            type=ref,event=branch,enable=${{ matrix.hadoop == 'v3' }},suffix='-snapshot-hadoop3'
+            type=ref,event=branch,enable=${{ matrix.hadoop == 'v2' }},suffix='-snapshot-hadoop2'
+            type=semver,event=tag,enable=${{ matrix.hadoop == 'v3' }},pattern={{version}}
+            type=semver,event=tag,enable=${{ matrix.hadoop == 'v2' }},pattern={{version}}-hadoop2
 
       - name: Print tags
         run: echo ${{ steps.meta.output.tags }}
@@ -115,9 +116,9 @@ jobs:
           images: |
             arctic163/optimizer-flink
           tags: |
-            type=ref,event=branch,enable=${{ matrix.flink == '1.14.6' }},value=master-snapshot
-            type=ref,event=branch,enable=${{ matrix.flink == '1.14.6' }},value=master-snapshot-flink1.14
-            type=ref,event=branch,enable=${{ matrix.flink == '1.15.3' }},value=master-snapshot-flink1.15
+            type=ref,event=branch,enable=${{ matrix.flink == '1.14.6' }},suffix='-snapshot'
+            type=ref,event=branch,enable=${{ matrix.flink == '1.14.6' }},suffix='-snapshot-flink1.14'
+            type=ref,event=branch,enable=${{ matrix.flink == '1.15.3' }},suffix='-snapshot-flink1.15'
             type=semver,enable=${{ matrix.flink == '1.14.6' }},pattern={{version}}
             type=semver,enable=${{ matrix.flink == '1.14.6' }},pattern={{version}}-flink1.14
             type=semver,enable=${{ matrix.flink == '1.15.3' }},pattern={{version}}-flink1.15

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -59,11 +59,11 @@ jobs:
         id: meta
         with:
           images: |
-            name=arctic163/amoro
+            name='arctic163/amoro'
           tags: |
-            type=ref,event=branch,enable=${{ matrix.hadoop == 'v3' }},suffix='-snapshot'
-            type=ref,event=branch,enable=${{ matrix.hadoop == 'v3' }},suffix='-snapshot-hadoop3'
-            type=ref,event=branch,enable=${{ matrix.hadoop == 'v2' }},suffix='-snapshot-hadoop2'
+            type=ref,event=branch,enable=${{ matrix.hadoop == 'v3' }},suffix=snapshot
+            type=ref,event=branch,enable=${{ matrix.hadoop == 'v3' }},suffix=snapshot-hadoop3
+            type=ref,event=branch,enable=${{ matrix.hadoop == 'v2' }},suffix=snapshot-hadoop2
             type=semver,event=tag,enable=${{ matrix.hadoop == 'v3' }},pattern={{version}}
             type=semver,event=tag,enable=${{ matrix.hadoop == 'v2' }},pattern={{version}}-hadoop2
 
@@ -76,8 +76,13 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Set Maven Build Properties
+        if: ${{ matrix.hadoop != "v3" }}
+        run: |
+          echo "MVN_HADOOP=-Dhadoop=${{ matrix.hadoop }}" >> $GITHUB_ENV
+
       - name: Build dist module with Maven
-        run: mvn clean install -pl 'dist' -am -e -Dhadoop=${{ matrix.hadoop }} -DskipTests -B -ntp
+        run: mvn clean install -pl 'dist' -am -e ${MVN_HADOOP} -DskipTests -B -ntp
 
       - name: Build and Push Amoro Docker Image
         uses: docker/build-push-action@v4

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -145,8 +145,15 @@ jobs:
       - name: Build optimizer module with Maven
         run: mvn clean install -pl 'ams/optimizer/flink-optimizer' -am -e ${OPTIMIZER_FLINK} -DskipTests -B -ntp
 
+      - name: Set ENV Amoro version
+        run: |
+          AMORO_VERSION=`cat ./pom.xml | grep 'amoro-parent' -C 3 | grep -Eo '<version>.*</version>' | awk -F'[><]' '{print $3}'` \
+          && echo "AMORO_VERSION=${AMORO_VERSION}" >> $GITHUB_ENV
+
       - name: Build and Push Flink Optimizer Docker Image
         uses: docker/build-push-action@v4
+        env:
+          AMORO_VERSION=
         with:
           context: .
           push: true
@@ -155,3 +162,4 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           build-args: |
             FLINK_VERSION=${{ matrix.flink }}
+            OPTIMIZER_JOB=ams/optimizer/flink-optimizer/target/flink-optimizer-${AMORO_VERSION}-jar-with-dependencies.jar

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -165,4 +165,4 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           build-args: |
             FLINK_VERSION=${{ matrix.flink }}
-            OPTIMIZER_JOB=ams/optimizer/flink-optimizer/target/flink-optimizer-${env.AMORO_VERSION}-jar-with-dependencies.jar
+            OPTIMIZER_JOB=ams/optimizer/flink-optimizer/target/flink-optimizer-${{ env.AMORO_VERSION }}-jar-with-dependencies.jar

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -29,7 +29,9 @@ on:
       - "v*"
 
 
-  workflow_dispatch:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   docker-amoro:

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -176,7 +176,7 @@ jobs:
     name: Push Amoro Quick-Demo Docker Image to Docker Hub
     runs-on: ubuntu-latest
     needs: docker-amoro
-    if: ${{ startsWith(github.repository, 'NetEase/') && starsWith(github.ref, 'refs/tags/' )}}
+    if: ${{ startsWith(github.repository, 'NetEase/') && startsWith(github.ref, 'refs/tags/' )}}
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 8

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -224,3 +224,4 @@ jobs:
           build-args: |
             AMORO_TAG=${{ steps.tag.outputs.AMORO_TAG }}
             FLINK_VERSION=1.17.1
+            ICEBERG_VERSION=1.3.1

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -199,6 +199,11 @@ jobs:
       - name: Print tags
         run: echo '${{ steps.meta.outputs.tags }}'
 
+      - name: Set Amoro Tag
+        id: tag
+        run: |
+          AMORO_TAG=${{ steps.meta.outputs.tags }} && echo "AMORO_TAG=${AMORO_TAG#*:} >> $GITHUB_OUTPUT
+
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
@@ -217,5 +222,5 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           build-args: |
-            AMORO_TAG: ${{ steps.meta.outputs.tags }}
-            FLINK_VERSION: 1.17.1
+            AMORO_TAG=${{ steps.tag.outputs.AMORO_TAG }}
+            FLINK_VERSION=1.17.1

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -59,7 +59,7 @@ jobs:
         id: meta
         with:
           images: |
-            name='arctic163/amoro'
+            name=arctic163/amoro
           tags: |
             type=ref,event=branch,enable=${{ matrix.hadoop == 'v3' }},suffix=-snapshot
             type=ref,event=branch,enable=${{ matrix.hadoop == 'v3' }},suffix=-snapshot-hadoop3
@@ -68,7 +68,7 @@ jobs:
             type=semver,event=tag,enable=${{ matrix.hadoop == 'v2' }},pattern={{version}}-hadoop2
 
       - name: Print tags
-        run: echo ${{ steps.meta.outputs.tags }}
+        run: echo '${{ steps.meta.outputs.tags }}'
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2
@@ -119,7 +119,7 @@ jobs:
         id: meta
         with:
           images: |
-            arctic163/optimizer-flink
+            name=arctic163/optimizer-flink
           tags: |
             type=ref,event=branch,enable=${{ matrix.flink == '1.14.6' }},suffix=-snapshot
             type=ref,event=branch,enable=${{ matrix.flink == '1.14.6' }},suffix=-snapshot-flink1.14
@@ -129,7 +129,7 @@ jobs:
             type=semver,enable=${{ matrix.flink == '1.15.3' }},pattern={{version}}-flink1.15
 
       - name: Print tags
-        run: echo ${{ steps.meta.outputs.tags }}
+        run: echo '${{ steps.meta.outputs.tags }}'
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -59,6 +59,8 @@ jobs:
         uses: docker/metadata-action@v5
         id: meta
         with:
+          flavor: |
+            latest=auto
           images: |
             name=arctic163/amoro
           tags: |
@@ -119,6 +121,8 @@ jobs:
         uses: docker/metadata-action@v5
         id: meta
         with:
+          flavor: |
+            latest=auto
           images: |
             name=arctic163/optimizer-flink
           tags: |
@@ -191,6 +195,8 @@ jobs:
         uses: docker/metadata-action@v5
         id: meta
         with:
+          flavor: |
+            latest=auto
           images: |
             name=arctic163/quickdemo
           tags: |

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -168,4 +168,4 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           build-args: |
             FLINK_VERSION=${{ matrix.flink }}
-            OPTIMIZER_JOB=ams/optimizer/flink-optimizer/target/flink-optimizer-${AMORO_VERSION}-jar-with-dependencies.jar
+            OPTIMIZER_JOB=ams/optimizer/flink-optimizer/target/flink-optimizer-${env.AMORO_VERSION}-jar-with-dependencies.jar

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -1,0 +1,149 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+# This workflow will build docker images when commit merged or pushed to master.
+# or tags pushed.
+
+name: Publish Docker Image
+
+on:
+  push:
+    branches:
+      - "master"
+      - "docker-image"
+    tags:
+      - "v*"
+
+
+  workflow_dispatch:
+
+jobs:
+  docker-amoro:
+    name: Push Amoro Docker Image to Docker Hub
+    runs-on: ubuntu-latest
+    if: ${{ startsWith(github.repository, 'NetEase/') }}
+    strategy:
+      matrix:
+        hadoop: ["v3"]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+          cache: maven
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Set up Docker tags
+        uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: arctic163/amoro
+          tags: |
+            type=ref,event=branch,enable=${{ matrix.hadoop == 'v3' }},value=master-snapshot
+            type=ref,event=branch,enable=${{ matrix.hadoop == 'v2' }},value=master-snapshot-hadoop2
+            type=semver,enable=${{ matrix.hadoop == 'v3' }},pattern={{version}}
+            type=semver,enable=${{ matrix.hadoop == 'v2' }},pattern={{version}}-hadoop2
+
+      - name: Print tags
+        run: echo ${{ steps.meta.output.tags }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build dist module with Maven
+        run: mvn clean install -pl 'dist' -am -e -Dhadoop=${{ matrix.hadoop }} -DskipTests -B -ntp
+
+      - name: Build and Push Amoro Docker Image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          file: docker/amoro/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.output.tags }}
+
+  docker-optimizer-flink:
+    name: Push Amoro Optimizer-Flink Docker Image to Docker Hub
+    runs-on: ubuntu-latest
+    if: ${{ startsWith(github.repository, 'NetEase/') }}
+    strategy:
+      matrix:
+        flink: [ "1.14.6", "1.15.3" ]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+          cache: maven
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Set up Docker tags
+        uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: arctic163/amoro
+          tags: |
+            type=ref,event=branch,enable=${{ matrix.flink == '1.14.6' }},value=master-snapshot
+            type=ref,event=branch,enable=${{ matrix.flink == '1.14.6' }},value=master-snapshot-flink1.14
+            type=ref,event=branch,enable=${{ matrix.flink == '1.15.3' }},value=master-snapshot-flink1.15
+            type=semver,enable=${{ matrix.flink == '1.14.6' }},pattern={{version}}
+            type=semver,enable=${{ matrix.flink == '1.14.6' }},pattern={{version}}-flink1.14
+            type=semver,enable=${{ matrix.flink == '1.15.3' }},pattern={{version}}-flink1.15
+
+      - name: Print tags
+        run: echo ${{ steps.meta.output.tags }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set optimizer flink version
+        run: |
+          OPTIMIZER_FLINK=${{ matrix.flink }} && \
+          echo "OPTIMIZER_FLINK=-Doptimizer.flink${OPTIMIZER_FLINK%.*}" >> $GITHUB_ENV
+
+      - name: Build all module with Maven
+        run: mvn clean install -pl 'ams/optimizer/flink-optimizer' -am -e ${OPTIMIZER_FLINK} -DskipTests -B -ntp
+
+      - name: Build and Push Amoro Docker Image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          file: docker/optimizer-flink/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.output.tags }}
+          build-args: |
+            FLINK_VERSION=${{ matrix.flink }}

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -61,9 +61,9 @@ jobs:
           images: |
             name='arctic163/amoro'
           tags: |
-            type=ref,event=branch,enable=${{ matrix.hadoop == 'v3' }},suffix=snapshot
-            type=ref,event=branch,enable=${{ matrix.hadoop == 'v3' }},suffix=snapshot-hadoop3
-            type=ref,event=branch,enable=${{ matrix.hadoop == 'v2' }},suffix=snapshot-hadoop2
+            type=ref,event=branch,enable=${{ matrix.hadoop == 'v3' }},suffix=-snapshot
+            type=ref,event=branch,enable=${{ matrix.hadoop == 'v3' }},suffix=-snapshot-hadoop3
+            type=ref,event=branch,enable=${{ matrix.hadoop == 'v2' }},suffix=-snapshot-hadoop2
             type=semver,event=tag,enable=${{ matrix.hadoop == 'v3' }},pattern={{version}}
             type=semver,event=tag,enable=${{ matrix.hadoop == 'v2' }},pattern={{version}}-hadoop2
 

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -145,6 +145,7 @@ jobs:
       - name: Set ENV Amoro version
         run: |
           AMORO_VERSION=`cat pom.xml | grep 'amoro-parent' -C 3 | grep -Eo '<version>.*</version>' | awk -F'[><]' '{print $3}'` \
+          && echo "$AMORO_VERSION" \
           && echo "AMORO_VERSION=${AMORO_VERSION}" >> $GITHUB_ENV
 
       - name: Build optimizer module with Maven

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -202,7 +202,7 @@ jobs:
       - name: Set Amoro Tag
         id: tag
         run: |
-          AMORO_TAG=${{ steps.meta.outputs.tags }} && echo "AMORO_TAG=${AMORO_TAG#*:} >> $GITHUB_OUTPUT
+          AMORO_TAG=${{ steps.meta.outputs.tags }} && echo "AMORO_TAG=${AMORO_TAG#*:}" >> $GITHUB_OUTPUT
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -148,7 +148,7 @@ jobs:
           AMORO_VERSION=`cat pom.xml | grep 'amoro-parent' -C 3 | grep -Eo '<version>.*</version>' | awk -F'[><]' '{print $3}'` \
           && echo "$AMORO_VERSION" \
           && echo "AMORO_VERSION=${AMORO_VERSION}" >> $GITHUB_ENV \
-          && echo "::set-output name=AMORO_VERSION::$AMORO_VERSION"
+          && echo "AMORO_VERSION=${AMORO_VERSION}" >> $GITHUB_OUTPUT
 
       - name: Build optimizer module with Maven
         run: mvn clean package -pl 'ams/optimizer/flink-optimizer' -am -e ${OPTIMIZER_FLINK} -DskipTests -B -ntp

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -68,7 +68,7 @@ jobs:
             type=semver,event=tag,enable=${{ matrix.hadoop == 'v2' }},pattern={{version}}-hadoop2
 
       - name: Print tags
-        run: echo ${{ steps.meta.output.tags }}
+        run: echo ${{ steps.meta.outputs.tags }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2
@@ -91,7 +91,7 @@ jobs:
           push: true
           file: docker/amoro/Dockerfile
           platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.output.tags }}
+          tags: ${{ steps.meta.outputs.tags }}
 
   docker-optimizer-flink:
     name: Push Amoro Optimizer-Flink Docker Image to Docker Hub
@@ -121,15 +121,15 @@ jobs:
           images: |
             arctic163/optimizer-flink
           tags: |
-            type=ref,event=branch,enable=${{ matrix.flink == '1.14.6' }},suffix='-snapshot'
-            type=ref,event=branch,enable=${{ matrix.flink == '1.14.6' }},suffix='-snapshot-flink1.14'
-            type=ref,event=branch,enable=${{ matrix.flink == '1.15.3' }},suffix='-snapshot-flink1.15'
+            type=ref,event=branch,enable=${{ matrix.flink == '1.14.6' }},suffix=-snapshot
+            type=ref,event=branch,enable=${{ matrix.flink == '1.14.6' }},suffix=-snapshot-flink1.14
+            type=ref,event=branch,enable=${{ matrix.flink == '1.15.3' }},suffix=-snapshot-flink1.15
             type=semver,enable=${{ matrix.flink == '1.14.6' }},pattern={{version}}
             type=semver,enable=${{ matrix.flink == '1.14.6' }},pattern={{version}}-flink1.14
             type=semver,enable=${{ matrix.flink == '1.15.3' }},pattern={{version}}-flink1.15
 
       - name: Print tags
-        run: echo ${{ steps.meta.output.tags }}
+        run: echo ${{ steps.meta.outputs.tags }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2
@@ -152,6 +152,6 @@ jobs:
           push: true
           file: docker/optimizer-flink/Dockerfile
           platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.output.tags }}
+          tags: ${{ steps.meta.outputs.tags }}
           build-args: |
             FLINK_VERSION=${{ matrix.flink }}

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -77,7 +77,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set Maven Build Properties
-        if: ${{ matrix.hadoop != "v3" }}
+        if: ${{ matrix.hadoop != 'v3' }}
         run: |
           echo "MVN_HADOOP=-Dhadoop=${{ matrix.hadoop }}" >> $GITHUB_ENV
 

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -206,7 +206,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build optimizer module with Maven
-        run: mvn clean package -pl 'flink/v.17/flink-runtime' -am -e -DskipTests -B -ntp
+        run: mvn clean package -pl 'flink/v1.17/flink-runtime' -am -e -DskipTests -B -ntp
 
       - name: Build and Push Flink Optimizer Docker Image
         uses: docker/build-push-action@v4

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -151,7 +151,8 @@ jobs:
       - name: Build optimizer module with Maven
         run: mvn clean package -pl 'ams/optimizer/flink-optimizer' -am -e ${OPTIMIZER_FLINK} -DskipTests -B -ntp
 
-      - run: ls -lh ams/optimizer/flink-optimizer/target/flink-optimizer-${AMORO_VERSION}-jar-with-dependencies.jar
+      - run: ls -lh ams/optimizer/flink-optimizer/target/flink-optimizer-${AMORO_VERSION}-jar-with-dependencies.jar \
+          && pwd
 
       - name: Build and Push Flink Optimizer Docker Image
         uses: docker/build-push-action@v4

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -58,7 +58,8 @@ jobs:
         uses: docker/metadata-action@v5
         id: meta
         with:
-          images: arctic163/amoro
+          images: |
+            arctic163/amoro
           tags: |
             type=ref,event=branch,enable=${{ matrix.hadoop == 'v3' }},value=master-snapshot
             type=ref,event=branch,enable=${{ matrix.hadoop == 'v2' }},value=master-snapshot-hadoop2
@@ -111,7 +112,8 @@ jobs:
         uses: docker/metadata-action@v5
         id: meta
         with:
-          images: arctic163/amoro
+          images: |
+            arctic163/optimizer-flink
           tags: |
             type=ref,event=branch,enable=${{ matrix.flink == '1.14.6' }},value=master-snapshot
             type=ref,event=branch,enable=${{ matrix.flink == '1.14.6' }},value=master-snapshot-flink1.14
@@ -134,10 +136,10 @@ jobs:
           OPTIMIZER_FLINK=${{ matrix.flink }} && \
           echo "OPTIMIZER_FLINK=-Doptimizer.flink${OPTIMIZER_FLINK%.*}" >> $GITHUB_ENV
 
-      - name: Build all module with Maven
+      - name: Build optimizer module with Maven
         run: mvn clean install -pl 'ams/optimizer/flink-optimizer' -am -e ${OPTIMIZER_FLINK} -DskipTests -B -ntp
 
-      - name: Build and Push Amoro Docker Image
+      - name: Build and Push Flink Optimizer Docker Image
         uses: docker/build-push-action@v4
         with:
           context: .

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -149,7 +149,9 @@ jobs:
           && echo "AMORO_VERSION=${AMORO_VERSION}" >> $GITHUB_ENV
 
       - name: Build optimizer module with Maven
-        run: mvn clean install -pl 'ams/optimizer/flink-optimizer' -am -e ${OPTIMIZER_FLINK} -DskipTests -B -ntp
+        run: mvn clean package -pl 'ams/optimizer/flink-optimizer' -am -e ${OPTIMIZER_FLINK} -DskipTests -B -ntp
+
+      - run: ls -lh ams/optimizer/flink-optimizer/target/flink-optimizer-${AMORO_VERSION}-jar-with-dependencies.jar
 
       - name: Build and Push Flink Optimizer Docker Image
         uses: docker/build-push-action@v4

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -153,9 +153,6 @@ jobs:
       - name: Build optimizer module with Maven
         run: mvn clean package -pl 'ams/optimizer/flink-optimizer' -am -e ${OPTIMIZER_FLINK} -DskipTests -B -ntp
 
-      - run: ls -lh ams/optimizer/flink-optimizer/target/flink-optimizer-${AMORO_VERSION}-jar-with-dependencies.jar \
-          && pwd
-
       - name: Build and Push Flink Optimizer Docker Image
         uses: docker/build-push-action@v4
         env:

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -143,10 +143,12 @@ jobs:
           echo "OPTIMIZER_FLINK=-Doptimizer.flink${OPTIMIZER_FLINK%.*}" >> $GITHUB_ENV
 
       - name: Set ENV Amoro version
+        id: version
         run: |
           AMORO_VERSION=`cat pom.xml | grep 'amoro-parent' -C 3 | grep -Eo '<version>.*</version>' | awk -F'[><]' '{print $3}'` \
           && echo "$AMORO_VERSION" \
-          && echo "AMORO_VERSION=${AMORO_VERSION}" >> $GITHUB_ENV
+          && echo "AMORO_VERSION=${AMORO_VERSION}" >> $GITHUB_ENV \
+          && echo "::set-output name=AMORO_VERSION::$AMORO_VERSION"
 
       - name: Build optimizer module with Maven
         run: mvn clean package -pl 'ams/optimizer/flink-optimizer' -am -e ${OPTIMIZER_FLINK} -DskipTests -B -ntp
@@ -156,6 +158,8 @@ jobs:
 
       - name: Build and Push Flink Optimizer Docker Image
         uses: docker/build-push-action@v4
+        env:
+          AMORO_VERSION: ${{ steps.version.outputs.AMORO_VERSION }}
         with:
           context: .
           push: true

--- a/docker/optimizer-flink/Dockerfile
+++ b/docker/optimizer-flink/Dockerfile
@@ -28,5 +28,5 @@ RUN cd $FLINK_HOME/lib \
     && chown flink:flink *.jar \
     && mkdir -p $FLINK_HOME/usrlib
 
-COPY $OPTIMIZER_JOB $FLINK_HOME/usrlib/optimizer-job.jar
+ADD $OPTIMIZER_JOB $FLINK_HOME/usrlib/optimizer-job.jar
 


### PR DESCRIPTION

## Why are the changes needed?

Auto build official docker image by github workflow actions. 

## Brief change log

- Add workflow to build official image Automated.

1. When commits merged into master or tags pushed,  `amoro`, `optimizer-flink`, `quickdemo` will be built automated.
2. When a PR is merged into the master branch, it triggers the building of a "master-snapshot" image. When a tag is pushed, it triggers the building of a "release" image, and the image tag matches the corresponding GitHub tag.




## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [X] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
