### PR TITLE
[hotfix]  Fix TableStatistics.setTotalFilesStat method's variable is assigned to itself

### DIFF
--- a/ams/server/src/main/java/com/netease/arctic/server/dashboard/model/TableStatistics.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/dashboard/model/TableStatistics.java
@@ -58,13 +58,6 @@ public class TableStatistics {
     this.totalFilesStat = totalFilesStat;
   }
 
-  public void setTotalFilesStat(FilesStatistics changeFs, FilesStatistics baseFs) {
-    setTotalFilesStat(new FilesStatistics.Builder()
-            .addFilesStatistics(changeFs)
-            .addFilesStatistics(baseFs)
-            .build());
-  }
-
   public Map<String, String> getSummary() {
     return summary;
   }

--- a/ams/server/src/main/java/com/netease/arctic/server/dashboard/model/TableStatistics.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/dashboard/model/TableStatistics.java
@@ -59,7 +59,10 @@ public class TableStatistics {
   }
 
   public void setTotalFilesStat(FilesStatistics changeFs, FilesStatistics baseFs) {
-    this.totalFilesStat = totalFilesStat;
+    setTotalFilesStat(new FilesStatistics.Builder()
+            .addFilesStatistics(changeFs)
+            .addFilesStatistics(baseFs)
+            .build());
   }
 
   public Map<String, String> getSummary() {

--- a/ams/server/src/main/java/com/netease/arctic/server/dashboard/utils/TableStatCollector.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/dashboard/utils/TableStatCollector.java
@@ -102,10 +102,7 @@ public class TableStatCollector {
     FilesStatistics changeFs = changeTableInfo.getTotalFilesStat();
     FilesStatistics baseFs = baseTableInfo.getTotalFilesStat();
 
-    overview.setTotalFilesStat(new FilesStatistics.Builder()
-        .addFilesStatistics(changeFs)
-        .addFilesStatistics(baseFs)
-        .build());
+    overview.setTotalFilesStat(changeFs, baseFs);
     return overview;
   }
 

--- a/ams/server/src/main/java/com/netease/arctic/server/dashboard/utils/TableStatCollector.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/dashboard/utils/TableStatCollector.java
@@ -102,7 +102,10 @@ public class TableStatCollector {
     FilesStatistics changeFs = changeTableInfo.getTotalFilesStat();
     FilesStatistics baseFs = baseTableInfo.getTotalFilesStat();
 
-    overview.setTotalFilesStat(changeFs, baseFs);
+    overview.setTotalFilesStat(new FilesStatistics.Builder()
+        .addFilesStatistics(changeFs)
+        .addFilesStatistics(baseFs)
+        .build());
     return overview;
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.netease.com/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

 Fix TableStatistics.setTotalFilesStat method's variable is assigned to itself

https://github.com/NetEase/amoro/blob/d0283bb8f71ad4fa0d7771cbecc03e5ef5332834/ams/server/src/main/java/com/netease/arctic/server/dashboard/model/TableStatistics.java#L61-L63

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
