### PR TITLE
[hotfix] Fix BaseOptimizingInput.options() putAll with itself as argument

### DIFF
--- a/core/src/main/java/com/netease/arctic/optimizing/BaseOptimizingInput.java
+++ b/core/src/main/java/com/netease/arctic/optimizing/BaseOptimizingInput.java
@@ -34,7 +34,7 @@ public abstract class BaseOptimizingInput implements TableOptimizing.OptimizingI
 
   @Override
   public void options(Map<String, String> options) {
-    options.putAll(options);
+    this.options.putAll(options);
   }
 
   @Override


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.netease.com/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

[hotfix] Fix BaseOptimizingInput.options() putAll with itself as argument

https://github.com/NetEase/amoro/blob/d0283bb8f71ad4fa0d7771cbecc03e5ef5332834/core/src/main/java/com/netease/arctic/optimizing/BaseOptimizingInput.java#L36-L38

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

-

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
