### PR TITLE
[Fix] Fix the format of thread name in DefaultTableService

### DIFF
--- a/ams/server/src/main/java/com/netease/arctic/server/table/DefaultTableService.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/table/DefaultTableService.java
@@ -58,7 +58,7 @@ public class DefaultTableService extends StatedPersistentBase implements TableSe
 
   private final ScheduledExecutorService tableExplorerScheduler = Executors.newSingleThreadScheduledExecutor(
       new ThreadFactoryBuilder()
-          .setNameFormat("table-explorer-scheduler")
+          .setNameFormat("table-explorer-scheduler-%d")
           .setDaemon(true)
           .build()
   );


### PR DESCRIPTION
 Fix the format of thread name in DefaultTableService