### PR TITLE
[AMORO-2090] Fix the problem of Optimizing bin-packing tasks being too small

### DIFF
--- a/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/AbstractPartitionPlan.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/optimizing/plan/AbstractPartitionPlan.java
@@ -289,7 +289,7 @@ public abstract class AbstractPartitionPlan implements PartitionEvaluator {
           allDataFiles.add(new FileTask(dataFile, deleteFiles, false)));
 
       List<List<FileTask>> packed = new BinPacking.ListPacker<FileTask>(
-          config.getMaxTaskSize(), Integer.MAX_VALUE, false)
+          Math.max(config.getTargetSize(), config.getMaxTaskSize()), Integer.MAX_VALUE, false)
           .pack(allDataFiles, f -> f.getFile().fileSizeInBytes());
 
       // collect


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.netease.com/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close #2090.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- binpack using max value of task size and target size

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / **no**)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
