### PR TITLE
Fix build.sh wrong args in README.md

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -28,7 +28,7 @@ You can build all image via script in current dir.
 or just build only one image.
 
 ```shell
-./build.sh ams
+./build.sh amoro
 ```
 
 - NOTICE: The ams image and flink image required the project had been packaged. 

--- a/docker/README.md
+++ b/docker/README.md
@@ -32,7 +32,7 @@ or just build only one image.
 ```
 
 - NOTICE: The amoro image, quickdemo image and optimizer-flink image required the project had been packaged. 
-so run `mvn package -pl '!trino'` before build amoro or optimizer-flink image.
+so run `mvn package -pl '!trino'` before build amoro, quickdemo or optimizer-flink image.
 
 You can speed up image building via 
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -31,7 +31,7 @@ or just build only one image.
 ./build.sh amoro
 ```
 
-- NOTICE: The amoro image and optimizer-flink image required the project had been packaged. 
+- NOTICE: The amoro image, quickdemo image and optimizer-flink image required the project had been packaged. 
 so run `mvn package -pl '!trino'` before build amoro or optimizer-flink image.
 
 You can speed up image building via 

--- a/docker/README.md
+++ b/docker/README.md
@@ -19,7 +19,7 @@
 
 We provide a bash script to help you build docker image easier.
 
-You can build all image via script in current dir.
+You can build all images via the script in current dir.
 
 ```shell
 ./build.sh all 
@@ -31,8 +31,8 @@ or just build only one image.
 ./build.sh amoro
 ```
 
-- NOTICE: The ams image and flink image required the project had been packaged. 
-so run `mvn package -pl '!trino'` before build ams or flink image.
+- NOTICE: The amoro image and optimizer-flink image required the project had been packaged. 
+so run `mvn package -pl '!trino'` before build amoro or optimizer-flink image.
 
 You can speed up image building via 
 
@@ -40,7 +40,7 @@ You can speed up image building via
 ./build.sh \
   --apache-archive https://mirrors.aliyun.com/apache \
   --debian-mirror https://mirrors.aliyun.com  \
-  flink
+  optimizer-flink
 ```
 
 more options see `./build.sh --help`


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.netease.com/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

"./build.sh ams" should be "./build.sh amoro" for refactoring code

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

-

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
