### PR TITLE
[Fix] Fix using the wrong summary map

### DIFF
--- a/ams/server/src/main/java/com/netease/arctic/server/dashboard/MixedAndIcebergTableDescriptor.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/dashboard/MixedAndIcebergTableDescriptor.java
@@ -210,13 +210,13 @@ public class MixedAndIcebergTableDescriptor extends PersistentBase
                       // normalize summary
                       Map<String, String> normalizeSummary =
                           com.google.common.collect.Maps.newHashMap(summary);
-                      summary.computeIfPresent(
+                      normalizeSummary.computeIfPresent(
                           SnapshotSummary.TOTAL_FILE_SIZE_PROP,
                           (k, v) -> byteToXB(Long.parseLong(summary.get(k))));
-                      summary.computeIfPresent(
+                      normalizeSummary.computeIfPresent(
                           SnapshotSummary.ADDED_FILE_SIZE_PROP,
                           (k, v) -> byteToXB(Long.parseLong(summary.get(k))));
-                      summary.computeIfPresent(
+                      normalizeSummary.computeIfPresent(
                           SnapshotSummary.REMOVED_FILE_SIZE_PROP,
                           (k, v) -> byteToXB(Long.parseLong(summary.get(k))));
                       amsTransactionsOfTable.setSummary(normalizeSummary);


### PR DESCRIPTION
## Why are the changes needed?

Using the wrong map when getting table transactions.
![image](https://github.com/NetEase/amoro/assets/68625618/fe2cf3f7-9995-4160-b98c-f419ab324b10)


## Brief change log

- Change the map to put.

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable)
