### PR TITLE
[Fix] Add hive-conf-dir option to paimon catalog

### DIFF
--- a/ams/server/src/main/java/com/netease/arctic/server/catalog/PaimonServerCatalog.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/catalog/PaimonServerCatalog.java
@@ -25,9 +25,13 @@ import com.netease.arctic.UnifiedCatalog;
 import com.netease.arctic.ams.api.CatalogMeta;
 import com.netease.arctic.table.TableMetaStore;
 import com.netease.arctic.utils.CatalogUtil;
+import org.apache.paimon.hive.HiveCatalogOptions;
 
+import java.io.File;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 
@@ -40,6 +44,11 @@ public class PaimonServerCatalog extends ExternalCatalog {
   protected PaimonServerCatalog(CatalogMeta metadata) {
     super(metadata);
     this.tableMetaStore = CatalogUtil.buildMetaStore(metadata);
+    Optional<URL> hiveSiteLocation = tableMetaStore.getHiveSiteLocation();
+    hiveSiteLocation.ifPresent(
+        url ->
+            metadata.catalogProperties.put(
+                HiveCatalogOptions.HIVE_CONF_DIR.key(), new File(url.getPath()).getParent()));
     this.paimonCatalog =
         doAs(() -> new CommonUnifiedCatalog(null, metadata, metadata.catalogProperties));
   }

--- a/ams/server/src/main/java/com/netease/arctic/server/dashboard/controller/CatalogController.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/dashboard/controller/CatalogController.java
@@ -73,7 +73,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
-import org.apache.paimon.options.CatalogOptions;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -372,22 +371,6 @@ public class CatalogController {
     return catalogMeta;
   }
 
-  private void checkPaimonCatalog(CatalogRegisterInfo info) {
-    if (!info.getTableFormatList().contains(TableFormat.PAIMON.name())) {
-      return;
-    }
-    Map<String, String> properties = info.getProperties();
-    if (!properties.containsKey(CatalogOptions.WAREHOUSE.key())) {
-      throw new IllegalArgumentException("Paimon catalog must have 'warehouse' property");
-    }
-
-    if (CATALOG_TYPE_HIVE.equalsIgnoreCase(info.getType())) {
-      if (!properties.containsKey(CatalogOptions.URI.key())) {
-        throw new IllegalArgumentException("Paimon hive catalog must have 'uri' property");
-      }
-    }
-  }
-
   private void checkHiddenProperties(CatalogRegisterInfo info) {
     getHiddenCatalogTableProperties().stream()
         .filter(info.getTableProperties()::containsKey)
@@ -473,8 +456,6 @@ public class CatalogController {
             String.format("Catalog type:%s require property:%s.", info.getType(), propertyName));
       }
     }
-
-    checkPaimonCatalog(info);
   }
 
   /** Get detail of some catalog. */


### PR DESCRIPTION
## Why are the changes needed?
I encountered a Kerberos error when there was no  hive-conf-dir parameter. However, this error does not always occur and may be related to the Kerberos environment of the server where AMS is located.
```
javax.security.sasl.SaslException: GSS initiate failed
        at com.sun.security.sasl.gsskerb.GssKrb5Client.evaluateChallenge(GssKrb5Client.java:211) ~[?:1.8.0_152]
        at org.apache.thrift.transport.TSaslClientTransport.handleSaslStartMessage(TSaslClientTransport.java:95) ~[libthrift-0.13.0.jar:0.13.0]
        at org.apache.thrift.transport.TSaslTransport.open(TSaslTransport.java:265) ~[libthrift-0.13.0.jar:0.13.0]
        at org.apache.thrift.transport.TSaslClientTransport.open(TSaslClientTransport.java:38) ~[libthrift-0.13.0.jar:0.13.0]
        at org.apache.hadoop.hive.thrift.client.TUGIAssumingTransport$1.run(TUGIAssumingTransport.java:52) ~[hive-shims-common-2.1.1.jar:2.1.1]
        at org.apache.hadoop.hive.thrift.client.TUGIAssumingTransport$1.run(TUGIAssumingTransport.java:49) ~[hive-shims-common-2.1.1.jar:2.1.1]
        at java.security.AccessController.doPrivileged(Native Method) ~[?:1.8.0_152]
        at javax.security.auth.Subject.doAs(Subject.java:422) ~[?:1.8.0_152]
        at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1938) ~[hadoop-common-2.10.2.jar:?]
        at org.apache.hadoop.hive.thrift.client.TUGIAssumingTransport.open(TUGIAssumingTransport.java:49) ~[hive-shims-common-2.1.1.jar:2.1.1]
        at org.apache.hadoop.hive.metastore.HiveMetaStoreClient.open(HiveMetaStoreClient.java:477) ~[hive-metastore-2.1.1.jar:2.1.1]
        at org.apache.hadoop.hive.metastore.HiveMetaStoreClient.<init>(HiveMetaStoreClient.java:285) ~[hive-metastore-2.1.1.jar:2.1.1]
        at sun.reflect.GeneratedConstructorAccessor48.newInstance(Unknown Source) ~[?:?]
        at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) ~[?:1.8.0_152]
        at java.lang.reflect.Constructor.newInstance(Constructor.java:423) ~[?:1.8.0_152]
        at org.apache.hadoop.hive.metastore.MetaStoreUtils.newInstance(MetaStoreUtils.java:1652) ~[hive-metastore-2.1.1.jar:2.1.1]
        at org.apache.hadoop.hive.metastore.RetryingMetaStoreClient.<init>(RetryingMetaStoreClient.java:80) ~[hive-metastore-2.1.1.jar:2.1.1]
        at org.apache.hadoop.hive.metastore.RetryingMetaStoreClient.getProxy(RetryingMetaStoreClient.java:130) ~[hive-metastore-2.1.1.jar:2.1.1]
        at org.apache.hadoop.hive.metastore.RetryingMetaStoreClient.getProxy(RetryingMetaStoreClient.java:101) ~[hive-metastore-2.1.1.jar:2.1.1]
        at sun.reflect.GeneratedMethodAccessor26.invoke(Unknown Source) ~[?:?]
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_152]
        at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_152]
        at org.apache.paimon.hive.HiveCatalog.createClient(HiveCatalog.java:646) ~[paimon-spark-common-0.5.0-incubating.jar:0.5.0-incubating]
        at org.apache.paimon.hive.HiveCatalog.<init>(HiveCatalog.java:136) ~[paimon-spark-common-0.5.0-incubating.jar:0.5.0-incubating]
        at org.apache.paimon.hive.HiveCatalogFactory.create(HiveCatalogFactory.java:89) ~[paimon-spark-common-0.5.0-incubating.jar:0.5.0-incubating]
        at org.apache.paimon.catalog.CatalogFactory.createCatalog(CatalogFactory.java:89) ~[paimon-spark-common-0.5.0-incubating.jar:0.5.0-incubating]
        at org.apache.paimon.catalog.CatalogFactory.createCatalog(CatalogFactory.java:58) ~[paimon-spark-common-0.5.0-incubating.jar:0.5.0-incubating]
        at com.netease.arctic.formats.paimon.PaimonCatalogFactory.paimonCatalog(PaimonCatalogFactory.java:57) ~[amoro-core-0.6.0-SNAPSHOT.jar:?]
        at com.netease.arctic.formats.paimon.PaimonCatalogFactory.create(PaimonCatalogFactory.java:41) ~[amoro-core-0.6.0-SNAPSHOT.jar:?]
        at com.netease.arctic.formats.paimon.PaimonCatalogFactory.create(PaimonCatalogFactory.java:34) ~[amoro-core-0.6.0-SNAPSHOT.jar:?]
        at com.netease.arctic.CommonUnifiedCatalog.initializeFormatCatalogs(CommonUnifiedCatalog.java:155) ~[amoro-core-0.6.0-SNAPSHOT.jar:?]
        at com.netease.arctic.CommonUnifiedCatalog.<init>(CommonUnifiedCatalog.java:49) ~[amoro-core-0.6.0-SNAPSHOT.jar:?]
        at com.netease.arctic.server.catalog.PaimonServerCatalog.lambda$new$0(PaimonServerCatalog.java:44) ~[amoro-ams-server-0.6.0-SNAPSHOT.jar:?]
        at com.netease.arctic.table.TableMetaStore.call(TableMetaStore.java:234) ~[amoro-core-0.6.0-SNAPSHOT.jar:?]
        at com.netease.arctic.table.TableMetaStore.lambda$doAs$0(TableMetaStore.java:209) ~[amoro-core-0.6.0-SNAPSHOT.jar:?]
        at java.security.AccessController.doPrivileged(Native Method) ~[?:1.8.0_152]
        at javax.security.auth.Subject.doAs(Subject.java:360) ~[?:1.8.0_152]
        at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1918) ~[hadoop-common-2.10.2.jar:?]
        at com.netease.arctic.table.TableMetaStore.doAs(TableMetaStore.java:209) ~[amoro-core-0.6.0-SNAPSHOT.jar:?]
        at com.netease.arctic.server.catalog.PaimonServerCatalog.doAs(PaimonServerCatalog.java:91) ~[amoro-ams-server-0.6.0-SNAPSHOT.jar:?]
        at com.netease.arctic.server.catalog.PaimonServerCatalog.<init>(PaimonServerCatalog.java:44) ~[amoro-ams-server-0.6.0-SNAPSHOT.jar:?]
        at com.netease.arctic.server.catalog.CatalogBuilder.buildServerCatalog(CatalogBuilder.java:28) ~[amoro-ams-server-0.6.0-SNAPSHOT.jar:?]
        at com.netease.arctic.server.table.DefaultTableService.initServerCatalog(DefaultTableService.java:132) ~[amoro-ams-server-0.6.0-SNAPSHOT.jar:?]
        at java.util.ArrayList.forEach(ArrayList.java:1257) [?:1.8.0_152]
        at com.netease.arctic.server.table.DefaultTableService.initialize(DefaultTableService.java:341) [amoro-ams-server-0.6.0-SNAPSHOT.jar:?]
        at com.netease.arctic.server.ArcticServiceContainer.startService(ArcticServiceContainer.java:146) [amoro-ams-server-0.6.0-SNAPSHOT.jar:?]
        at com.netease.arctic.server.ArcticServiceContainer.main(ArcticServiceContainer.java:109) [amoro-ams-server-0.6.0-SNAPSHOT.jar:?]
Caused by: org.ietf.jgss.GSSException: No valid credentials provided (Mechanism level: Failed to find any Kerberos tgt)
        at sun.security.jgss.krb5.Krb5InitCredential.getInstance(Krb5InitCredential.java:147) ~[?:1.8.0_152]
        at sun.security.jgss.krb5.Krb5MechFactory.getCredentialElement(Krb5MechFactory.java:122) ~[?:1.8.0_152]
        at sun.security.jgss.krb5.Krb5MechFactory.getMechanismContext(Krb5MechFactory.java:187) ~[?:1.8.0_152]
        at sun.security.jgss.GSSManagerImpl.getMechanismContext(GSSManagerImpl.java:224) ~[?:1.8.0_152]
        at sun.security.jgss.GSSContextImpl.initSecContext(GSSContextImpl.java:212) ~[?:1.8.0_152]
        at sun.security.jgss.GSSContextImpl.initSecContext(GSSContextImpl.java:179) ~[?:1.8.0_152]
        at com.sun.security.sasl.gsskerb.GssKrb5Client.evaluateChallenge(GssKrb5Client.java:192) ~[?:1.8.0_152]
        ... 46 more
```

## Brief change log
- Add hive-conf-dir option for paimon catalog in PaimonServerCatalog
- Remove catalog option check in CatalogController

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / **no**)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
