### PR TITLE
[Fix] Delete the database at the end of each UT.

### DIFF
--- a/ams/server/src/test/java/com/netease/arctic/server/dashboard/TestServerTableDescriptor.java
+++ b/ams/server/src/test/java/com/netease/arctic/server/dashboard/TestServerTableDescriptor.java
@@ -41,7 +41,7 @@ public abstract class TestServerTableDescriptor extends TableCatalogTestBase {
 
   @Before
   public void before() {
-      getAmoroCatalog().createDatabase(TEST_DB);
+    getAmoroCatalog().createDatabase(TEST_DB);
     try {
       getAmoroCatalogTestHelper().createTable(TEST_DB, TEST_TABLE);
     } catch (Exception e) {

--- a/ams/server/src/test/java/com/netease/arctic/server/dashboard/TestServerTableDescriptor.java
+++ b/ams/server/src/test/java/com/netease/arctic/server/dashboard/TestServerTableDescriptor.java
@@ -41,7 +41,9 @@ public abstract class TestServerTableDescriptor extends TableCatalogTestBase {
 
   @Before
   public void before() {
-    getAmoroCatalog().createDatabase(TEST_DB);
+    if (!getAmoroCatalog().exist(TEST_DB)){
+      getAmoroCatalog().createDatabase(TEST_DB);
+    }
     try {
       getAmoroCatalogTestHelper().createTable(TEST_DB, TEST_TABLE);
     } catch (Exception e) {

--- a/ams/server/src/test/java/com/netease/arctic/server/dashboard/TestServerTableDescriptor.java
+++ b/ams/server/src/test/java/com/netease/arctic/server/dashboard/TestServerTableDescriptor.java
@@ -41,9 +41,7 @@ public abstract class TestServerTableDescriptor extends TableCatalogTestBase {
 
   @Before
   public void before() {
-    if (!getAmoroCatalog().exist(TEST_DB)){
       getAmoroCatalog().createDatabase(TEST_DB);
-    }
     try {
       getAmoroCatalogTestHelper().createTable(TEST_DB, TEST_TABLE);
     } catch (Exception e) {

--- a/core/src/test/java/com/netease/arctic/catalog/TableTestBase.java
+++ b/core/src/test/java/com/netease/arctic/catalog/TableTestBase.java
@@ -84,6 +84,7 @@ public abstract class TableTestBase extends CatalogTestBase {
   @After
   public void dropTable() {
     getCatalog().dropTable(tableTestHelper.id(), true);
+    getCatalog().dropDatabase(TableTestHelper.TEST_DB_NAME);
   }
 
   protected ArcticTable getArcticTable() {

--- a/core/src/test/java/com/netease/arctic/io/TestRecoverableArcticFileIO.java
+++ b/core/src/test/java/com/netease/arctic/io/TestRecoverableArcticFileIO.java
@@ -114,6 +114,7 @@ public class TestRecoverableArcticFileIO extends TableTestBase {
     arcticFileIO.asFileSystemIO().makeDirectories(dir);
     Assert.assertTrue(recoverableArcticFileIO.isEmptyDirectory(dir));
     Assert.assertFalse(recoverableArcticFileIO.isEmptyDirectory(getArcticTable().location()));
+    arcticFileIO.deleteFile(dir);
   }
 
   @Test


### PR DESCRIPTION
## Why are the changes needed?
Due to not deleting the database created by each UT at the end, an error occurs when other UTs create the database, resulting in the failure of the entire CI.

## Brief change log
- Drop database at TableTestBase end

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / **no**)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
