### PR TITLE
[AMORO-2196] Fix scale out error

### DIFF
--- a/ams/server/src/main/java/com/netease/arctic/server/manager/FlinkOptimizerContainer.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/manager/FlinkOptimizerContainer.java
@@ -285,8 +285,8 @@ public class FlinkOptimizerContainer extends AbstractResourceContainer {
             break;
           }
           LOG.info("{}", readLine);
-          if (commandReader != null) {
-            value = commandReader.apply(readLine);
+          if ((value = commandReader.apply(readLine)) != null) {
+            break;
           }
         }
         return value;
@@ -317,8 +317,7 @@ public class FlinkOptimizerContainer extends AbstractResourceContainer {
       String releaseCmd = exportCmd + " && " + releaseCommand;
       String[] cmd = {"/bin/sh", "-c", releaseCmd};
       LOG.info("Releasing flink optimizer using command: " + releaseCmd);
-      Process exec = Runtime.getRuntime().exec(cmd);
-      fetchCommandOutput(exec, null);
+      Runtime.getRuntime().exec(cmd);
     } catch (IOException e) {
       throw new UncheckedIOException("Failed to release flink optimizer.", e);
     }


### PR DESCRIPTION

## Why are the changes needed?

Close #2196.

## Brief change log

- Break out of the loop when the value is successfully fetched.
- Remove useless 'fetch' for 'releaseOptimizer'.

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable)
