### PR TITLE
[AMORO-2168]:Fix-2183 FileNameRules adapt to hidden filename.

### DIFF
--- a/core/src/main/java/com/netease/arctic/data/FileNameRules.java
+++ b/core/src/main/java/com/netease/arctic/data/FileNameRules.java
@@ -54,7 +54,7 @@ import java.util.regex.Pattern;
 public class FileNameRules {
 
   private static final String KEYED_FILE_NAME_PATTERN_STRING =
-      "(\\d+)-(\\w+)-(\\d+)-(\\d+)-(\\d+)-.*";
+      "\\.?(\\d+)-(\\w+)-(\\d+)-(\\d+)-(\\d+)-.*";
   private static final Pattern KEYED_FILE_NAME_PATTERN =
       Pattern.compile(KEYED_FILE_NAME_PATTERN_STRING);
 

--- a/core/src/test/java/com/netease/arctic/io/TestFileNameGenerator.java
+++ b/core/src/test/java/com/netease/arctic/io/TestFileNameGenerator.java
@@ -96,4 +96,23 @@ public class TestFileNameGenerator {
     Assert.assertEquals(fileMeta.type(), DataFileType.INSERT_FILE);
     Assert.assertEquals(fileMeta.transactionId(), 2L);
   }
+
+  @Test
+  public void testHiddenFileParse() {
+    String path = "hdfs://test/animal_partition_two/hive/.5-I-2-00000-941953957-0000000001.parquet";
+    DefaultKeyedFile.FileMeta fileMeta = FileNameRules.parseBase(path);
+    Assert.assertEquals(fileMeta.node(), DataTreeNode.of(3, 1));
+    Assert.assertEquals(fileMeta.type(), DataFileType.BASE_FILE);
+    Assert.assertEquals(fileMeta.transactionId(), 2L);
+
+    long txId = FileNameRules.parseTransactionId(path);
+    Assert.assertEquals(2L, txId);
+
+    String invalidPath =
+        "hdfs://test/animal_partition_two/hive/A5-I-2-00000-941953957-0000000001.parquet";
+    fileMeta = FileNameRules.parseBase(invalidPath);
+    Assert.assertEquals(fileMeta.node(), DataTreeNode.of(0, 0));
+    Assert.assertEquals(fileMeta.type(), DataFileType.BASE_FILE);
+    Assert.assertEquals(fileMeta.transactionId(), 0L);
+  }
 }


### PR DESCRIPTION
 

## Why are the changes needed?
 
Fix the bug introduced by #2183

In #2183 , the writer attempted to maintain consistency between the connector and HiveServer reads by writing to a hidden file, but overlooked adapting to the new file name style during the process of parsing the relevant parameters from the file name.

## Brief change log


- Make the regular expression for parsing the Key Filename adapt to hidden file names.

## How was this patch tested?

- [X] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [X] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (  no) 
