### PR TITLE
[AMORO-2225] Change the default value of `self-optimizing.major.trigger.duplicate-ratio` to 0.1

### DIFF
--- a/core/src/main/java/com/netease/arctic/table/TableProperties.java
+++ b/core/src/main/java/com/netease/arctic/table/TableProperties.java
@@ -101,7 +101,7 @@ public class TableProperties {
 
   public static final String SELF_OPTIMIZING_MAJOR_TRIGGER_DUPLICATE_RATIO =
       "self-optimizing.major.trigger.duplicate-ratio";
-  public static final double SELF_OPTIMIZING_MAJOR_TRIGGER_DUPLICATE_RATIO_DEFAULT = 0.5;
+  public static final double SELF_OPTIMIZING_MAJOR_TRIGGER_DUPLICATE_RATIO_DEFAULT = 0.1;
 
   public static final String SELF_OPTIMIZING_FULL_TRIGGER_INTERVAL =
       "self-optimizing.full.trigger.interval";
@@ -271,11 +271,6 @@ public class TableProperties {
   public static final String LOG_STORE_PROPERTIES_PREFIX = "properties.";
 
   public static final String OWNER = "owner";
-
-  /** enable consistent write for hive store */
-  public static final String HIVE_CONSISTENT_WRITE_ENABLED = "hive.consistent-write.enabled";
-
-  public static final String HIVE_CONSISTENT_WRITE_ENABLED_DEFAULT = "true";
 
   /** table format related properties */
   public static final String TABLE_FORMAT = "table-format";

--- a/core/src/main/java/com/netease/arctic/utils/TablePropertyUtil.java
+++ b/core/src/main/java/com/netease/arctic/utils/TablePropertyUtil.java
@@ -40,32 +40,6 @@ public class TablePropertyUtil {
 
   public static final StructLike EMPTY_STRUCT = GenericRecord.create(new Schema());
 
-  /**
-   * Decode string to max transaction id map of each partition.
-   *
-   * @param spec table partition spec
-   * @param value string value
-   * @return max transaction id map of each partition
-   */
-  public static StructLikeMap<Long> decodePartitionMaxTxId(PartitionSpec spec, String value) {
-    try {
-      StructLikeMap<Long> results = StructLikeMap.create(spec.partitionType());
-      TypeReference<Map<String, Long>> typeReference = new TypeReference<Map<String, Long>>() {};
-      Map<String, Long> map = new ObjectMapper().readValue(value, typeReference);
-      for (String key : map.keySet()) {
-        if (spec.isUnpartitioned()) {
-          results.put(null, map.get(key));
-        } else {
-          StructLike partitionData = ArcticDataFiles.data(spec, key);
-          results.put(partitionData, map.get(key));
-        }
-      }
-      return results;
-    } catch (JsonProcessingException e) {
-      throw new UnsupportedOperationException("Failed to decode partition max txId ", e);
-    }
-  }
-
   public static StructLikeMap<Map<String, String>> decodePartitionProperties(
       PartitionSpec spec, String value) {
     try {
@@ -191,12 +165,5 @@ public class TablePropertyUtil {
     } else {
       return Long.parseLong(watermarkValue);
     }
-  }
-
-  public static boolean hiveConsistentWriteEnabled(Map<String, String> properties) {
-    return Boolean.parseBoolean(
-        properties.getOrDefault(
-            TableProperties.HIVE_CONSISTENT_WRITE_ENABLED,
-            TableProperties.HIVE_CONSISTENT_WRITE_ENABLED_DEFAULT));
   }
 }

--- a/docs/user-guides/configurations.md
+++ b/docs/user-guides/configurations.md
@@ -39,7 +39,7 @@ Self-optimizing configurations are applicable to both Iceberg Format and Mixed s
 | self-optimizing.fragment-ratio                      | 8                | The fragment file size threshold. We could divide self-optimizing.target-size by this ratio to get the actual fragment file size           |
 | self-optimizing.minor.trigger.file-count            | 12               | The minimum numbers of fragment files to trigger minor optimizing   |
 | self-optimizing.minor.trigger.interval              | 3600000(1 hour)  | The time interval in milliseconds to trigger minor optimizing                         |
-| self-optimizing.major.trigger.duplicate-ratio       | 0.5              | The ratio of duplicate data of segment files to trigger major optimizing  |
+| self-optimizing.major.trigger.duplicate-ratio       | 0.1              | The ratio of duplicate data of segment files to trigger major optimizing  |
 | self-optimizing.full.trigger.interval               | -1(closed)       | The time interval in milliseconds to trigger full optimizing
 | self-optimizing.full.rewrite-all-files              | true             | Whether full optimizing rewrites all files or skips files that do not need to be optimized |
 
@@ -116,4 +116,4 @@ If using Iceberg Format，please refer to [Iceberg configurations](https://icebe
 |-----------------------------------|------------------|--------------------------------------------------------------------------------------------------------|
 | base.hive.auto-sync-schema-change | true             | Whether synchronize schema changes of Hive Table from HMS                                              |
 | base.hive.auto-sync-data-write    | false            | Whether synchronize data changes of Hive Table from HMS, this should be true when writing to Hive      |
-| hive.consitent-write.enabled      | true             | The files written to the Hive directory will be hidden files and renamed to visible files upon commit. |
+| base.hive.consistent-write.enabled | true            | To avoid writing dirty data, the files written to the Hive directory will be hidden files and renamed to visible files upon commit. |

--- a/flink/flink-common/src/main/java/com/netease/arctic/flink/write/FlinkTaskWriterBuilder.java
+++ b/flink/flink-common/src/main/java/com/netease/arctic/flink/write/FlinkTaskWriterBuilder.java
@@ -18,6 +18,7 @@
 
 package com.netease.arctic.flink.write;
 
+import com.netease.arctic.hive.HiveTableProperties;
 import com.netease.arctic.hive.io.writer.AdaptHiveOperateToTableRelation;
 import com.netease.arctic.hive.io.writer.AdaptHiveOutputFileFactory;
 import com.netease.arctic.hive.table.HiveLocationKind;
@@ -37,7 +38,6 @@ import com.netease.arctic.table.TableProperties;
 import com.netease.arctic.table.UnkeyedTable;
 import com.netease.arctic.table.WriteOperationKind;
 import com.netease.arctic.utils.SchemaUtil;
-import com.netease.arctic.utils.TablePropertyUtil;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.iceberg.FileFormat;
@@ -152,7 +152,10 @@ public class FlinkTaskWriterBuilder implements TaskWriterBuilder<RowData> {
         TypeUtil.reassignIds(
             FlinkSchemaUtil.convert(FlinkSchemaUtil.toSchema(flinkSchema)), schema);
     boolean hiveConsistentWriteEnabled =
-        TablePropertyUtil.hiveConsistentWriteEnabled(table.properties());
+        PropertyUtil.propertyAsBoolean(
+            table.properties(),
+            HiveTableProperties.HIVE_CONSISTENT_WRITE_ENABLED,
+            HiveTableProperties.HIVE_CONSISTENT_WRITE_ENABLED_DEFAULT);
 
     OutputFileFactory outputFileFactory =
         locationKind == HiveLocationKind.INSTANT

--- a/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/FlinkTaskWriterBuilder.java
+++ b/flink/v1.15/flink/src/main/java/com/netease/arctic/flink/write/FlinkTaskWriterBuilder.java
@@ -18,6 +18,7 @@
 
 package com.netease.arctic.flink.write;
 
+import com.netease.arctic.hive.HiveTableProperties;
 import com.netease.arctic.hive.io.writer.AdaptHiveOperateToTableRelation;
 import com.netease.arctic.hive.io.writer.AdaptHiveOutputFileFactory;
 import com.netease.arctic.hive.table.HiveLocationKind;
@@ -37,7 +38,6 @@ import com.netease.arctic.table.TableProperties;
 import com.netease.arctic.table.UnkeyedTable;
 import com.netease.arctic.table.WriteOperationKind;
 import com.netease.arctic.utils.SchemaUtil;
-import com.netease.arctic.utils.TablePropertyUtil;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.iceberg.FileFormat;
@@ -152,7 +152,10 @@ public class FlinkTaskWriterBuilder implements TaskWriterBuilder<RowData> {
         TypeUtil.reassignIds(
             FlinkSchemaUtil.convert(FlinkSchemaUtil.toSchema(flinkSchema)), schema);
     boolean hiveConsistentWriteEnabled =
-        TablePropertyUtil.hiveConsistentWriteEnabled(table.properties());
+        PropertyUtil.propertyAsBoolean(
+            table.properties(),
+            HiveTableProperties.HIVE_CONSISTENT_WRITE_ENABLED,
+            HiveTableProperties.HIVE_CONSISTENT_WRITE_ENABLED_DEFAULT);
 
     OutputFileFactory outputFileFactory =
         locationKind == HiveLocationKind.INSTANT

--- a/hive/src/main/java/com/netease/arctic/hive/HiveTableProperties.java
+++ b/hive/src/main/java/com/netease/arctic/hive/HiveTableProperties.java
@@ -54,6 +54,7 @@ public class HiveTableProperties {
 
   /** enable consistent write for hive store */
   public static final String HIVE_CONSISTENT_WRITE_ENABLED = "base.hive.consistent-write.enabled";
+
   public static final boolean HIVE_CONSISTENT_WRITE_ENABLED_DEFAULT = true;
 
   public static final String ALLOW_HIVE_TABLE_EXISTED = "allow-hive-table-existed";

--- a/hive/src/main/java/com/netease/arctic/hive/HiveTableProperties.java
+++ b/hive/src/main/java/com/netease/arctic/hive/HiveTableProperties.java
@@ -52,6 +52,10 @@ public class HiveTableProperties {
   public static final String REFRESH_HIVE_INTERVAL = "base.hive.refresh-interval";
   public static final long REFRESH_HIVE_INTERVAL_DEFAULT = -1L;
 
+  /** enable consistent write for hive store */
+  public static final String HIVE_CONSISTENT_WRITE_ENABLED = "base.hive.consistent-write.enabled";
+  public static final boolean HIVE_CONSISTENT_WRITE_ENABLED_DEFAULT = true;
+
   public static final String ALLOW_HIVE_TABLE_EXISTED = "allow-hive-table-existed";
 
   public static final String WATERMARK_HIVE = "watermark.hive";

--- a/hive/src/main/java/com/netease/arctic/hive/HiveTableProperties.java
+++ b/hive/src/main/java/com/netease/arctic/hive/HiveTableProperties.java
@@ -52,9 +52,7 @@ public class HiveTableProperties {
   public static final String REFRESH_HIVE_INTERVAL = "base.hive.refresh-interval";
   public static final long REFRESH_HIVE_INTERVAL_DEFAULT = -1L;
 
-  /** enable consistent write for hive store */
   public static final String HIVE_CONSISTENT_WRITE_ENABLED = "base.hive.consistent-write.enabled";
-
   public static final boolean HIVE_CONSISTENT_WRITE_ENABLED_DEFAULT = true;
 
   public static final String ALLOW_HIVE_TABLE_EXISTED = "allow-hive-table-existed";

--- a/hive/src/main/java/com/netease/arctic/hive/io/writer/AdaptHiveGenericTaskWriterBuilder.java
+++ b/hive/src/main/java/com/netease/arctic/hive/io/writer/AdaptHiveGenericTaskWriterBuilder.java
@@ -19,6 +19,7 @@
 package com.netease.arctic.hive.io.writer;
 
 import com.netease.arctic.data.ChangeAction;
+import com.netease.arctic.hive.HiveTableProperties;
 import com.netease.arctic.hive.table.HiveLocationKind;
 import com.netease.arctic.hive.table.SupportHive;
 import com.netease.arctic.hive.utils.TableTypeUtil;
@@ -38,7 +39,6 @@ import com.netease.arctic.table.TableProperties;
 import com.netease.arctic.table.UnkeyedTable;
 import com.netease.arctic.table.WriteOperationKind;
 import com.netease.arctic.utils.SchemaUtil;
-import com.netease.arctic.utils.TablePropertyUtil;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.MetricsModes;
@@ -55,7 +55,7 @@ import org.apache.iceberg.util.PropertyUtil;
 
 import java.util.Locale;
 
-/** Builder to create writers for {@link KeyedTable} writting {@link Record}. */
+/** Builder to create writers for {@link KeyedTable} writing {@link Record}. */
 public class AdaptHiveGenericTaskWriterBuilder implements TaskWriterBuilder<Record> {
 
   private final ArcticTable table;
@@ -71,7 +71,11 @@ public class AdaptHiveGenericTaskWriterBuilder implements TaskWriterBuilder<Reco
 
   private AdaptHiveGenericTaskWriterBuilder(ArcticTable table) {
     this.table = table;
-    this.hiveConsistentWrite = TablePropertyUtil.hiveConsistentWriteEnabled(table.properties());
+    this.hiveConsistentWrite =
+        PropertyUtil.propertyAsBoolean(
+            table.properties(),
+            HiveTableProperties.HIVE_CONSISTENT_WRITE_ENABLED,
+            HiveTableProperties.HIVE_CONSISTENT_WRITE_ENABLED_DEFAULT);
   }
 
   public AdaptHiveGenericTaskWriterBuilder withTransactionId(Long transactionId) {

--- a/hive/src/test/java/com/netease/arctic/hive/io/HiveDataTestHelpers.java
+++ b/hive/src/test/java/com/netease/arctic/hive/io/HiveDataTestHelpers.java
@@ -19,6 +19,7 @@
 package com.netease.arctic.hive.io;
 
 import com.netease.arctic.data.ChangeAction;
+import com.netease.arctic.hive.HiveTableProperties;
 import com.netease.arctic.hive.io.reader.AdaptHiveGenericKeyedDataReader;
 import com.netease.arctic.hive.io.reader.AdaptHiveGenericUnkeyedDataReader;
 import com.netease.arctic.hive.io.writer.AdaptHiveGenericTaskWriterBuilder;
@@ -34,7 +35,6 @@ import com.netease.arctic.table.MetadataColumns;
 import com.netease.arctic.table.UnkeyedTable;
 import com.netease.arctic.utils.ArcticTableUtil;
 import com.netease.arctic.utils.TableFileUtil;
-import com.netease.arctic.utils.TablePropertyUtil;
 import com.netease.arctic.utils.map.StructLikeCollections;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.Schema;
@@ -44,6 +44,7 @@ import org.apache.iceberg.data.Record;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.io.TaskWriter;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.util.PropertyUtil;
 import org.junit.Assert;
 
 import java.io.IOException;
@@ -151,7 +152,10 @@ public class HiveDataTestHelpers {
    */
   public static void assertWriteConsistentFilesName(SupportHive table, List<DataFile> files) {
     boolean consistentWriteEnabled =
-        TablePropertyUtil.hiveConsistentWriteEnabled(table.properties());
+        PropertyUtil.propertyAsBoolean(
+            table.properties(),
+            HiveTableProperties.HIVE_CONSISTENT_WRITE_ENABLED,
+            HiveTableProperties.HIVE_CONSISTENT_WRITE_ENABLED_DEFAULT);
     String hiveLocation = table.hiveLocation();
     for (DataFile f : files) {
       String filename = TableFileUtil.getFileName(f.path().toString());

--- a/hive/src/test/java/com/netease/arctic/hive/op/TestOverwriteFiles.java
+++ b/hive/src/test/java/com/netease/arctic/hive/op/TestOverwriteFiles.java
@@ -5,6 +5,7 @@ import static com.netease.arctic.hive.op.UpdateHiveFiles.DELETE_UNTRACKED_HIVE_F
 import com.netease.arctic.TableTestHelper;
 import com.netease.arctic.ams.api.TableFormat;
 import com.netease.arctic.catalog.CatalogTestHelper;
+import com.netease.arctic.hive.HiveTableProperties;
 import com.netease.arctic.hive.MixedHiveTableTestBase;
 import com.netease.arctic.hive.TestHMS;
 import com.netease.arctic.hive.catalog.HiveCatalogTestHelper;
@@ -54,8 +55,7 @@ public class TestOverwriteFiles extends MixedHiveTableTestBase {
         new HiveTableTestHelper(
             true,
             false,
-            ImmutableMap.of(
-                com.netease.arctic.table.TableProperties.HIVE_CONSISTENT_WRITE_ENABLED, "false"))
+            ImmutableMap.of(HiveTableProperties.HIVE_CONSISTENT_WRITE_ENABLED, "false"))
       },
       {
         new HiveCatalogTestHelper(TableFormat.MIXED_HIVE, TEST_HMS.getHiveConf()),
@@ -66,8 +66,7 @@ public class TestOverwriteFiles extends MixedHiveTableTestBase {
         new HiveTableTestHelper(
             false,
             false,
-            ImmutableMap.of(
-                com.netease.arctic.table.TableProperties.HIVE_CONSISTENT_WRITE_ENABLED, "false"))
+            ImmutableMap.of(HiveTableProperties.HIVE_CONSISTENT_WRITE_ENABLED, "false"))
       }
     };
   }

--- a/hive/src/test/java/com/netease/arctic/hive/op/TestRewriteFiles.java
+++ b/hive/src/test/java/com/netease/arctic/hive/op/TestRewriteFiles.java
@@ -5,6 +5,7 @@ import static com.netease.arctic.hive.op.UpdateHiveFiles.DELETE_UNTRACKED_HIVE_F
 import com.netease.arctic.TableTestHelper;
 import com.netease.arctic.ams.api.TableFormat;
 import com.netease.arctic.catalog.CatalogTestHelper;
+import com.netease.arctic.hive.HiveTableProperties;
 import com.netease.arctic.hive.MixedHiveTableTestBase;
 import com.netease.arctic.hive.TestHMS;
 import com.netease.arctic.hive.catalog.HiveCatalogTestHelper;
@@ -58,8 +59,7 @@ public class TestRewriteFiles extends MixedHiveTableTestBase {
         new HiveTableTestHelper(
             true,
             false,
-            ImmutableMap.of(
-                com.netease.arctic.table.TableProperties.HIVE_CONSISTENT_WRITE_ENABLED, "false"))
+            ImmutableMap.of(HiveTableProperties.HIVE_CONSISTENT_WRITE_ENABLED, "false"))
       },
       {
         new HiveCatalogTestHelper(TableFormat.MIXED_HIVE, TEST_HMS.getHiveConf()),
@@ -70,8 +70,7 @@ public class TestRewriteFiles extends MixedHiveTableTestBase {
         new HiveTableTestHelper(
             false,
             false,
-            ImmutableMap.of(
-                com.netease.arctic.table.TableProperties.HIVE_CONSISTENT_WRITE_ENABLED, "false"))
+            ImmutableMap.of(HiveTableProperties.HIVE_CONSISTENT_WRITE_ENABLED, "false"))
       }
     };
   }

--- a/hive/src/test/java/com/netease/arctic/hive/op/TestRewritePartitions.java
+++ b/hive/src/test/java/com/netease/arctic/hive/op/TestRewritePartitions.java
@@ -23,6 +23,7 @@ import static com.netease.arctic.hive.op.UpdateHiveFiles.DELETE_UNTRACKED_HIVE_F
 import com.netease.arctic.TableTestHelper;
 import com.netease.arctic.ams.api.TableFormat;
 import com.netease.arctic.catalog.CatalogTestHelper;
+import com.netease.arctic.hive.HiveTableProperties;
 import com.netease.arctic.hive.MixedHiveTableTestBase;
 import com.netease.arctic.hive.TestHMS;
 import com.netease.arctic.hive.catalog.HiveCatalogTestHelper;
@@ -69,8 +70,7 @@ public class TestRewritePartitions extends MixedHiveTableTestBase {
         new HiveTableTestHelper(
             false,
             true,
-            ImmutableMap.of(
-                com.netease.arctic.table.TableProperties.HIVE_CONSISTENT_WRITE_ENABLED, "false"))
+            ImmutableMap.of(HiveTableProperties.HIVE_CONSISTENT_WRITE_ENABLED, "false"))
       }
     };
   }

--- a/spark/v3.1/spark/src/main/java/com/netease/arctic/spark/io/TaskWriters.java
+++ b/spark/v3.1/spark/src/main/java/com/netease/arctic/spark/io/TaskWriters.java
@@ -18,6 +18,7 @@
 
 package com.netease.arctic.spark.io;
 
+import com.netease.arctic.hive.HiveTableProperties;
 import com.netease.arctic.hive.io.writer.AdaptHiveOutputFileFactory;
 import com.netease.arctic.hive.table.SupportHive;
 import com.netease.arctic.io.writer.ChangeTaskWriter;
@@ -29,7 +30,6 @@ import com.netease.arctic.table.PrimaryKeySpec;
 import com.netease.arctic.table.TableProperties;
 import com.netease.arctic.table.UnkeyedTable;
 import com.netease.arctic.utils.SchemaUtil;
-import com.netease.arctic.utils.TablePropertyUtil;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
@@ -144,7 +144,11 @@ public class TaskWriters {
         InternalRowFileAppenderFactory.builderFor(icebergTable, schema, dsSchema)
             .writeHive(isHiveTable)
             .build();
-    boolean hiveConsistentWrite = TablePropertyUtil.hiveConsistentWriteEnabled(table.properties());
+    boolean hiveConsistentWrite =
+        PropertyUtil.propertyAsBoolean(
+            table.properties(),
+            HiveTableProperties.HIVE_CONSISTENT_WRITE_ENABLED,
+            HiveTableProperties.HIVE_CONSISTENT_WRITE_ENABLED_DEFAULT);
     OutputFileFactory outputFileFactory;
     if (isHiveTable && isOverwrite) {
       outputFileFactory =

--- a/spark/v3.2/spark/src/main/java/com/netease/arctic/spark/io/TaskWriters.java
+++ b/spark/v3.2/spark/src/main/java/com/netease/arctic/spark/io/TaskWriters.java
@@ -18,6 +18,7 @@
 
 package com.netease.arctic.spark.io;
 
+import com.netease.arctic.hive.HiveTableProperties;
 import com.netease.arctic.hive.io.writer.AdaptHiveOutputFileFactory;
 import com.netease.arctic.hive.table.SupportHive;
 import com.netease.arctic.io.writer.ChangeTaskWriter;
@@ -29,7 +30,6 @@ import com.netease.arctic.table.PrimaryKeySpec;
 import com.netease.arctic.table.TableProperties;
 import com.netease.arctic.table.UnkeyedTable;
 import com.netease.arctic.utils.SchemaUtil;
-import com.netease.arctic.utils.TablePropertyUtil;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
@@ -144,7 +144,11 @@ public class TaskWriters {
         InternalRowFileAppenderFactory.builderFor(icebergTable, schema, dsSchema)
             .writeHive(isHiveTable)
             .build();
-    boolean hiveConsistentWrite = TablePropertyUtil.hiveConsistentWriteEnabled(table.properties());
+    boolean hiveConsistentWrite =
+        PropertyUtil.propertyAsBoolean(
+            table.properties(),
+            HiveTableProperties.HIVE_CONSISTENT_WRITE_ENABLED,
+            HiveTableProperties.HIVE_CONSISTENT_WRITE_ENABLED_DEFAULT);
     OutputFileFactory outputFileFactory;
     if (isHiveTable && isOverwrite) {
       outputFileFactory =

--- a/spark/v3.2/spark/src/test/java/com/netease/arctic/spark/writer/TestSparkWriter.java
+++ b/spark/v3.2/spark/src/test/java/com/netease/arctic/spark/writer/TestSparkWriter.java
@@ -5,6 +5,7 @@ import static com.netease.arctic.table.TableProperties.CHANGE_FILE_FORMAT;
 import static com.netease.arctic.table.TableProperties.DEFAULT_FILE_FORMAT;
 
 import com.netease.arctic.ams.api.TableFormat;
+import com.netease.arctic.hive.HiveTableProperties;
 import com.netease.arctic.hive.io.HiveDataTestHelpers;
 import com.netease.arctic.hive.table.SupportHive;
 import com.netease.arctic.spark.io.TaskWriters;
@@ -14,7 +15,6 @@ import com.netease.arctic.spark.test.utils.RecordGenerator;
 import com.netease.arctic.spark.test.utils.TestTableUtil;
 import com.netease.arctic.table.ArcticTable;
 import com.netease.arctic.table.PrimaryKeySpec;
-import com.netease.arctic.table.TableProperties;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Files;
@@ -202,7 +202,7 @@ public class TestSparkWriter extends SparkTableTestBase {
                 .collect(Collectors.toList()));
     Set<InternalRow> result = new HashSet<>();
     Iterators.addAll(result, concat.iterator());
-    Assertions.assertEquals(result, records.stream().collect(Collectors.toSet()));
+    Assertions.assertEquals(result, new HashSet<>(records));
   }
 
   private CloseableIterable<InternalRow> readParquet(Schema schema, String path) {
@@ -213,8 +213,7 @@ public class TestSparkWriter extends SparkTableTestBase {
                 fileSchema -> SparkParquetReaders.buildReader(schema, fileSchema, new HashMap<>()))
             .caseSensitive(false);
 
-    CloseableIterable<InternalRow> iterable = builder.build();
-    return iterable;
+    return builder.build();
   }
 
   private CloseableIterable<InternalRow> readOrc(Schema schema, String path) {
@@ -224,8 +223,7 @@ public class TestSparkWriter extends SparkTableTestBase {
             .createReaderFunc(fileSchema -> new SparkOrcReader(schema, fileSchema, new HashMap<>()))
             .caseSensitive(false);
 
-    CloseableIterable<InternalRow> iterable = builder.build();
-    return iterable;
+    return builder.build();
   }
 
   private InternalRow geneRowData() {
@@ -246,7 +244,7 @@ public class TestSparkWriter extends SparkTableTestBase {
             schema,
             builder ->
                 builder.withProperty(
-                    TableProperties.HIVE_CONSISTENT_WRITE_ENABLED, enableConsistentWrite + ""));
+                    HiveTableProperties.HIVE_CONSISTENT_WRITE_ENABLED, enableConsistentWrite + ""));
     StructType dsSchema = SparkSchemaUtil.convert(schema);
     List<Record> records = RecordGenerator.buildFor(schema).build().records(10);
     try (TaskWriter<InternalRow> writer =

--- a/spark/v3.3/spark/src/main/java/com/netease/arctic/spark/io/TaskWriters.java
+++ b/spark/v3.3/spark/src/main/java/com/netease/arctic/spark/io/TaskWriters.java
@@ -18,6 +18,7 @@
 
 package com.netease.arctic.spark.io;
 
+import com.netease.arctic.hive.HiveTableProperties;
 import com.netease.arctic.hive.io.writer.AdaptHiveOutputFileFactory;
 import com.netease.arctic.hive.table.SupportHive;
 import com.netease.arctic.io.writer.ChangeTaskWriter;
@@ -29,7 +30,6 @@ import com.netease.arctic.table.PrimaryKeySpec;
 import com.netease.arctic.table.TableProperties;
 import com.netease.arctic.table.UnkeyedTable;
 import com.netease.arctic.utils.SchemaUtil;
-import com.netease.arctic.utils.TablePropertyUtil;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
@@ -144,7 +144,11 @@ public class TaskWriters {
         InternalRowFileAppenderFactory.builderFor(icebergTable, schema, dsSchema)
             .writeHive(isHiveTable)
             .build();
-    boolean hiveConsistentWrite = TablePropertyUtil.hiveConsistentWriteEnabled(table.properties());
+    boolean hiveConsistentWrite =
+        PropertyUtil.propertyAsBoolean(
+            table.properties(),
+            HiveTableProperties.HIVE_CONSISTENT_WRITE_ENABLED,
+            HiveTableProperties.HIVE_CONSISTENT_WRITE_ENABLED_DEFAULT);
     OutputFileFactory outputFileFactory;
     if (isHiveTable && isOverwrite) {
       outputFileFactory =

--- a/spark/v3.3/spark/src/test/java/com/netease/arctic/spark/writer/TestSparkWriter.java
+++ b/spark/v3.3/spark/src/test/java/com/netease/arctic/spark/writer/TestSparkWriter.java
@@ -5,6 +5,7 @@ import static com.netease.arctic.table.TableProperties.CHANGE_FILE_FORMAT;
 import static com.netease.arctic.table.TableProperties.DEFAULT_FILE_FORMAT;
 
 import com.netease.arctic.ams.api.TableFormat;
+import com.netease.arctic.hive.HiveTableProperties;
 import com.netease.arctic.hive.io.HiveDataTestHelpers;
 import com.netease.arctic.hive.table.SupportHive;
 import com.netease.arctic.spark.io.TaskWriters;
@@ -14,7 +15,6 @@ import com.netease.arctic.spark.test.utils.RecordGenerator;
 import com.netease.arctic.spark.test.utils.TestTableUtil;
 import com.netease.arctic.table.ArcticTable;
 import com.netease.arctic.table.PrimaryKeySpec;
-import com.netease.arctic.table.TableProperties;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Files;
@@ -202,7 +202,7 @@ public class TestSparkWriter extends SparkTableTestBase {
                 .collect(Collectors.toList()));
     Set<InternalRow> result = new HashSet<>();
     Iterators.addAll(result, concat.iterator());
-    Assertions.assertEquals(result, records.stream().collect(Collectors.toSet()));
+    Assertions.assertEquals(result, new HashSet<>(records));
   }
 
   private CloseableIterable<InternalRow> readParquet(Schema schema, String path) {
@@ -213,8 +213,7 @@ public class TestSparkWriter extends SparkTableTestBase {
                 fileSchema -> SparkParquetReaders.buildReader(schema, fileSchema, new HashMap<>()))
             .caseSensitive(false);
 
-    CloseableIterable<InternalRow> iterable = builder.build();
-    return iterable;
+    return builder.build();
   }
 
   private CloseableIterable<InternalRow> readOrc(Schema schema, String path) {
@@ -224,8 +223,7 @@ public class TestSparkWriter extends SparkTableTestBase {
             .createReaderFunc(fileSchema -> new SparkOrcReader(schema, fileSchema, new HashMap<>()))
             .caseSensitive(false);
 
-    CloseableIterable<InternalRow> iterable = builder.build();
-    return iterable;
+    return builder.build();
   }
 
   private InternalRow geneRowData() {
@@ -246,7 +244,7 @@ public class TestSparkWriter extends SparkTableTestBase {
             schema,
             builder ->
                 builder.withProperty(
-                    TableProperties.HIVE_CONSISTENT_WRITE_ENABLED, enableConsistentWrite + ""));
+                    HiveTableProperties.HIVE_CONSISTENT_WRITE_ENABLED, enableConsistentWrite + ""));
     StructType dsSchema = SparkSchemaUtil.convert(schema);
     List<Record> records = RecordGenerator.buildFor(schema).build().records(10);
     try (TaskWriter<InternalRow> writer =


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.netease.com/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close #225.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- Change the default value of `self-optimizing.major.trigger.duplicate-ratio` to 0.1
- Rename property `hive.consistent-write.enabled` to `base.hive.consistent-write.enabled` and move it to HiveTableProperties.
- Polish some codes.

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable)
