### PR TITLE
[AMORO-2244] fix 0.4.x `Failed` optimizing tasks should not change to `Prepared`

### DIFF
--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/OptimizeTaskItem.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/optimize/OptimizeTaskItem.java
@@ -171,8 +171,10 @@ public class OptimizeTaskItem extends IJDBCService {
     long reportTime = System.currentTimeMillis();
     lock.lock();
     try {
-      Preconditions.checkArgument(optimizeRuntime.getStatus() != OptimizeStatus.Prepared,
-          "task prepared, can't on prepared");
+      // Some tasks may not need to be executed, these tasks can change to Prepared from Init directly
+      Preconditions.checkArgument(
+          optimizeRuntime.getStatus() == OptimizeStatus.Init || optimizeRuntime.getStatus() == OptimizeStatus.Executing,
+          optimizeRuntime.getStatus() + " task can't on prepared, only support Init or Executing");
       OptimizeTaskRuntime newRuntime = optimizeRuntime.clone();
       if (newRuntime.getExecuteTime() == OptimizeTaskRuntime.INVALID_TIME) {
         newRuntime.setExecuteTime(preparedTime);

--- a/ams/ams-server/src/main/java/com/netease/arctic/ams/server/service/impl/OptimizeQueueService.java
+++ b/ams/ams-server/src/main/java/com/netease/arctic/ams/server/service/impl/OptimizeQueueService.java
@@ -494,7 +494,7 @@ public class OptimizeQueueService extends IJDBCService implements Closeable {
                   String pattern = ".*(\\d{5}-)" + task.getOptimizeRuntime().getAttemptId() + "(-\\d{10}).*";
                   if (Pattern.matches(pattern, fileLocation)) {
                     arcticTable.io().deleteFile(fileLocation);
-                    LOG.debug("delete file {} by produced failed optimize task.", fileLocation);
+                    LOG.info("delete file {} by produced failed optimize task.", fileLocation);
                   }
                 }
               }


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.netease.com/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close #2244 .

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- check task status to be Init/Executing when on prepared
- change delete file log from DEBUG to INFO

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / **no**)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
