### PR TITLE
[AMORO-2250][AMS] After disabed self-optimizing, change the status of the table to IDLE

### DIFF
--- a/ams/server/src/main/java/com/netease/arctic/server/table/executor/TableRuntimeRefreshExecutor.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/table/executor/TableRuntimeRefreshExecutor.java
@@ -20,6 +20,7 @@ package com.netease.arctic.server.table.executor;
 
 import com.netease.arctic.AmoroTable;
 import com.netease.arctic.server.optimizing.plan.OptimizingEvaluator;
+import com.netease.arctic.server.table.TableConfiguration;
 import com.netease.arctic.server.table.TableManager;
 import com.netease.arctic.server.table.TableRuntime;
 import com.netease.arctic.table.ArcticTable;
@@ -55,6 +56,15 @@ public class TableRuntimeRefreshExecutor extends BaseTableExecutor {
             pendingInput);
         tableRuntime.setPendingInput(pendingInput);
       }
+    }
+  }
+
+  @Override
+  public void handleConfigChanged(TableRuntime tableRuntime, TableConfiguration originalConfig) {
+    // After disabling self-optimizing, use dispose() to change the status of the table to IDLE
+    if (originalConfig.getOptimizingConfig().isEnabled()
+        && !tableRuntime.getTableConfiguration().getOptimizingConfig().isEnabled()) {
+      tableRuntime.dispose();
     }
   }
 


### PR DESCRIPTION

## Why are the changes needed?

Close #2250.

## Brief change log

- After disable self-optimizing, call `com.netease.arctic.server.table.TableRuntime#dispose`

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / **no**)
- If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
