### PR TITLE
fix the optimizer-job.jar path error in the document

### DIFF
--- a/docs/admin-guides/managing-optimizers.md
+++ b/docs/admin-guides/managing-optimizers.md
@@ -171,7 +171,7 @@ You can submit optimizer in your own Flink task development platform or local Fl
  -Dtaskmanager.memory.network.max=32mb \
  -Dtaskmanager.memory.network.min=32mb \
  -c com.netease.arctic.optimizer.flink.FlinkOptimizer \
- ${ARCTIC_HOME}/plugin/flink/optimizer-job.jar \
+ ${ARCTIC_HOME}/plugin/optimizer/flink/optimizer-job.jar \
  -a 127.0.0.1:1261 \
  -g flinkGroup \
  -p 1 \


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.netease.com/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

The optimizer-job.jar path in the "deploy external optimizer" document is incorrect

## Brief change log
Change the path from ${ARCTIC_HOME}/plugin/flink/optimizer-job.jar to ${ARCTIC_HOME}/plugin/optimizer/flink/optimizer-job.jar

## Documentation

- Does this pull request introduce a new feature?  no
