### PR TITLE
[BugFix][Spark]: Add default value of table-filters in spark scan builder to avoid NPE when comparing the table scan.

### DIFF
--- a/spark/v3.1/spark/src/main/java/com/netease/arctic/spark/reader/KeyedSparkBatchScan.java
+++ b/spark/v3.1/spark/src/main/java/com/netease/arctic/spark/reader/KeyedSparkBatchScan.java
@@ -30,6 +30,7 @@ import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.CloseableIterator;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.Spark3Util;
 import org.apache.iceberg.spark.SparkSchemaUtil;
@@ -69,6 +70,10 @@ public class KeyedSparkBatchScan implements Scan, Batch, SupportsReportStatistic
       Schema expectedSchema,
       List<Expression> filters,
       CaseInsensitiveStringMap options) {
+    Preconditions.checkNotNull(table, "table must not be null");
+    Preconditions.checkNotNull(expectedSchema, "expectedSchema must not be null");
+    Preconditions.checkNotNull(filters, "filters must not be null");
+
     this.table = table;
     this.caseSensitive = caseSensitive;
     this.expectedSchema = expectedSchema;
@@ -124,10 +129,8 @@ public class KeyedSparkBatchScan implements Scan, Batch, SupportsReportStatistic
     if (tasks == null) {
       KeyedTableScan scan = table.newScan();
 
-      if (filterExpressions != null) {
-        for (Expression filter : filterExpressions) {
-          scan = scan.filter(filter);
-        }
+      for (Expression filter : filterExpressions) {
+        scan = scan.filter(filter);
       }
       long startTime = System.currentTimeMillis();
       LOG.info("mor statistics plan task start");
@@ -146,12 +149,9 @@ public class KeyedSparkBatchScan implements Scan, Batch, SupportsReportStatistic
 
   @Override
   public String description() {
-    if (filterExpressions != null) {
-      String filters =
-          filterExpressions.stream().map(Spark3Util::describe).collect(Collectors.joining(", "));
-      return String.format("%s [filters=%s]", table, filters);
-    }
-    return "";
+    String filters =
+        filterExpressions.stream().map(Spark3Util::describe).collect(Collectors.joining(", "));
+    return String.format("%s [filters=%s]", table, filters);
   }
 
   @Override

--- a/spark/v3.1/spark/src/main/java/com/netease/arctic/spark/reader/SparkScanBuilder.java
+++ b/spark/v3.1/spark/src/main/java/com/netease/arctic/spark/reader/SparkScanBuilder.java
@@ -59,7 +59,7 @@ public class SparkScanBuilder
   private Schema schema = null;
   private StructType requestedProjection;
   private final boolean caseSensitive;
-  private List<Expression> filterExpressions = null;
+  private List<Expression> filterExpressions = Lists.newArrayList();
   private Filter[] pushedFilters = NO_FILTERS;
 
   public SparkScanBuilder(SparkSession spark, ArcticTable table, CaseInsensitiveStringMap options) {
@@ -110,7 +110,7 @@ public class SparkScanBuilder
   }
 
   private Expression filterExpression() {
-    if (filterExpressions != null) {
+    if (!filterExpressions.isEmpty()) {
       return filterExpressions.stream().reduce(Expressions.alwaysTrue(), Expressions::and);
     }
     return Expressions.alwaysTrue();

--- a/spark/v3.2/spark/src/main/java/com/netease/arctic/spark/reader/SparkScanBuilder.java
+++ b/spark/v3.2/spark/src/main/java/com/netease/arctic/spark/reader/SparkScanBuilder.java
@@ -59,7 +59,7 @@ public class SparkScanBuilder
   private Schema schema = null;
   private StructType requestedProjection;
   private final boolean caseSensitive;
-  private List<Expression> filterExpressions = null;
+  private List<Expression> filterExpressions = Lists.newArrayList();
   private Filter[] pushedFilters = NO_FILTERS;
 
   public SparkScanBuilder(SparkSession spark, ArcticTable table, CaseInsensitiveStringMap options) {
@@ -110,7 +110,7 @@ public class SparkScanBuilder
   }
 
   private Expression filterExpression() {
-    if (filterExpressions != null) {
+    if (!filterExpressions.isEmpty()) {
       return filterExpressions.stream().reduce(Expressions.alwaysTrue(), Expressions::and);
     }
     return Expressions.alwaysTrue();

--- a/spark/v3.3/spark/src/main/java/com/netease/arctic/spark/reader/SparkScanBuilder.java
+++ b/spark/v3.3/spark/src/main/java/com/netease/arctic/spark/reader/SparkScanBuilder.java
@@ -60,7 +60,7 @@ public class SparkScanBuilder
   private Schema schema = null;
   private StructType requestedProjection;
   private final boolean caseSensitive;
-  private List<Expression> filterExpressions = null;
+  private List<Expression> filterExpressions = Lists.newArrayList();
   private Filter[] pushedFilters = NO_FILTERS;
 
   public SparkScanBuilder(SparkSession spark, ArcticTable table, CaseInsensitiveStringMap options) {
@@ -111,7 +111,7 @@ public class SparkScanBuilder
   }
 
   private Expression filterExpression() {
-    if (filterExpressions != null) {
+    if (!filterExpressions.isEmpty()) {
       return filterExpressions.stream().reduce(Expressions.alwaysTrue(), Expressions::and);
     }
     return Expressions.alwaysTrue();


### PR DESCRIPTION
 

## Why are the changes needed?
 
The NPE may be throwed when spark comparing the table scan during plan.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- Add default value to SparkScanBuilder

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [X] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? ( no) 
