### PR TITLE
[AMORO-2246] Make Trino stats only calculate on base store

### DIFF
--- a/trino/src/main/java/com/netease/arctic/trino/keyed/KeyedConnectorMetadata.java
+++ b/trino/src/main/java/com/netease/arctic/trino/keyed/KeyedConnectorMetadata.java
@@ -63,9 +63,6 @@ import io.trino.spi.expression.ConnectorExpression;
 import io.trino.spi.expression.Variable;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.TupleDomain;
-import io.trino.spi.statistics.ColumnStatistics;
-import io.trino.spi.statistics.DoubleRange;
-import io.trino.spi.statistics.Estimate;
 import io.trino.spi.statistics.TableStatistics;
 import io.trino.spi.type.TypeManager;
 import org.apache.iceberg.PartitionSpecParser;
@@ -88,7 +85,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /** Metadata for Keyed Table */
 public class KeyedConnectorMetadata implements ConnectorMetadata {
@@ -455,15 +451,7 @@ public class KeyedConnectorMetadata implements ConnectorMetadata {
                       handle,
                       arcticTable.asKeyedTable().baseTable().currentSnapshot().snapshotId()),
                   arcticTable.asKeyedTable().baseTable());
-          TableStatistics changeTableStatistics =
-              TableStatisticsReader.getTableStatistics(
-                  typeManager,
-                  session,
-                  withSnapshotId(
-                      handle,
-                      arcticTable.asKeyedTable().changeTable().currentSnapshot().snapshotId()),
-                  arcticTable.asKeyedTable().changeTable());
-          return computeBothTablesStatistics(baseTableStatistics, changeTableStatistics);
+          return baseTableStatistics;
         });
   }
 
@@ -486,72 +474,6 @@ public class KeyedConnectorMetadata implements ConnectorMetadata {
         handle.getUpdatedColumns(),
         handle.isRecordScannedFiles(),
         handle.getMaxScannedFileSize());
-  }
-
-  private static TableStatistics computeBothTablesStatistics(
-      TableStatistics baseTableStatistics, TableStatistics changeTableStatistics) {
-    double baseRowCount = baseTableStatistics.getRowCount().getValue();
-    double changeRowCount = changeTableStatistics.getRowCount().getValue();
-    Estimate rowCount = Estimate.of(baseRowCount + changeRowCount);
-    Map<ColumnHandle, ColumnStatistics> baseColumnStatistics =
-        baseTableStatistics.getColumnStatistics();
-    Map<ColumnHandle, ColumnStatistics> changeColumnStatistics =
-        changeTableStatistics.getColumnStatistics();
-    Map<ColumnHandle, ColumnStatistics> newColumnStatistics = new HashMap<>();
-    changeColumnStatistics.forEach(
-        (columnHandle, statisticsOfChangeColumn) -> {
-          ColumnStatistics statisticsOfBaseColumn = baseColumnStatistics.get(columnHandle);
-          ColumnStatistics.Builder columnBuilder = new ColumnStatistics.Builder();
-
-          Estimate baseDataSize = statisticsOfBaseColumn.getDataSize();
-          Estimate changeDataSize = statisticsOfChangeColumn.getDataSize();
-          if (!baseDataSize.isUnknown() || !changeDataSize.isUnknown()) {
-            double value =
-                Stream.of(baseDataSize, changeDataSize)
-                    .mapToDouble(Estimate::getValue)
-                    .average()
-                    .getAsDouble();
-            columnBuilder.setDataSize(
-                Double.isNaN(value) ? Estimate.unknown() : Estimate.of(value));
-          }
-
-          Optional<DoubleRange> baseRange = statisticsOfBaseColumn.getRange();
-          Optional<DoubleRange> changeRange = statisticsOfChangeColumn.getRange();
-          if (baseRange.isPresent() && changeRange.isPresent()) {
-            columnBuilder.setRange(DoubleRange.union(baseRange.get(), changeRange.get()));
-          } else {
-            columnBuilder.setRange(baseRange.isPresent() ? baseRange : changeRange);
-          }
-
-          Estimate baseNullsFraction = statisticsOfBaseColumn.getNullsFraction();
-          Estimate changeNullsFraction = statisticsOfChangeColumn.getNullsFraction();
-          if (!baseNullsFraction.isUnknown() && !changeNullsFraction.isUnknown()) {
-            columnBuilder.setNullsFraction(
-                Estimate.of(
-                    ((baseNullsFraction.getValue() * baseRowCount)
-                            + (statisticsOfChangeColumn.getNullsFraction().getValue()
-                                * changeRowCount))
-                        / (baseRowCount + changeRowCount)));
-          } else {
-            columnBuilder.setNullsFraction(
-                baseNullsFraction.isUnknown() ? changeNullsFraction : baseNullsFraction);
-          }
-
-          Estimate baseDistinctValue = statisticsOfBaseColumn.getDistinctValuesCount();
-          Estimate changeDistinctValue = statisticsOfChangeColumn.getDistinctValuesCount();
-          if (!baseDistinctValue.isUnknown() || !changeDistinctValue.isUnknown()) {
-            double value =
-                Stream.of(baseDistinctValue, changeDistinctValue)
-                    .mapToDouble(Estimate::getValue)
-                    .map(dataSize -> Double.isNaN(dataSize) ? 0 : dataSize)
-                    .sum();
-            columnBuilder.setDistinctValuesCount(Estimate.of(value));
-          }
-
-          ColumnStatistics columnStatistics = columnBuilder.build();
-          newColumnStatistics.put(columnHandle, columnStatistics);
-        });
-    return new TableStatistics(rowCount, newColumnStatistics);
   }
 
   private static Set<Integer> identityPartitionColumnsInAllSpecs(ArcticTable table) {

--- a/trino/src/test/java/com/netease/arctic/trino/arctic/TestBaseArcticPrimaryTable.java
+++ b/trino/src/test/java/com/netease/arctic/trino/arctic/TestBaseArcticPrimaryTable.java
@@ -57,10 +57,10 @@ public class TestBaseArcticPrimaryTable extends TableTestBaseWithInitDataForTrin
         .skippingTypesCheck()
         .matches(
             "VALUES "
-                + "('id', NULL, NULL, 0e0, NULL, '1', '6'), "
-                + "('name$name', 4805e-1, NULL, 0e0, NULL, NULL, NULL), "
+                + "('id', NULL, NULL, 0e0, NULL, '1', '4'), "
+                + "('name$name', 548e0, NULL, 0e0, NULL, NULL, NULL), "
                 + "('op_time', NULL, NULL, 0e0, NULL, '2022-01-01 12:00:00.000000', '2022-01-04 12:00:00.000000'), "
-                + "(NULL, NULL, NULL, NULL, 7e0, NULL, NULL)");
+                + "(NULL, NULL, NULL, NULL, 4e0, NULL, NULL)");
   }
 
   @Test

--- a/trino/src/test/java/com/netease/arctic/trino/arctic/TestHiveTable.java
+++ b/trino/src/test/java/com/netease/arctic/trino/arctic/TestHiveTable.java
@@ -283,15 +283,15 @@ public class TestHiveTable extends TestHiveTableBaseForTrino {
         .skippingTypesCheck()
         .matches(
             "VALUES "
-                + "('id', NULL, NULL, 0e0, NULL, '1', '6'), "
+                + "('id', NULL, NULL, 0e0, NULL, '1', '4'), "
                 + "('op_time', NULL, NULL, 0e0, NULL, '2022-01-01 12:00:00.000000', '2022-01-04 12:00:00.000000'), "
                 + "('op_time_with_zone', NULL, NULL, 0e0, NULL,'2022-01-01 12:00:00.000 UTC', '2022-01-04 12:00:00.000 UTC'), "
-                + "('d$d', NULL, NULL, 0e0, NULL, '100.0', '105.0'), "
+                + "('d$d', NULL, NULL, 0e0, NULL, '100.0', '103.0'), "
                 + "('map_name', NULL, NULL, NULL, NULL, NULL, NULL), "
                 + "('array_name', NULL, NULL, NULL, NULL, NULL, NULL), "
                 + "('struct_name', NULL, NULL, NULL, NULL, NULL, NULL), "
-                + "('name', 618e0, NULL, 0e0, NULL, NULL, NULL), "
-                + "(NULL, NULL, NULL, NULL, 9e0, NULL, NULL)");
+                + "('name', 548e0, NULL, 0e0, NULL, NULL, NULL), "
+                + "(NULL, NULL, NULL, NULL, 4e0, NULL, NULL)");
   }
 
   @Test
@@ -300,17 +300,17 @@ public class TestHiveTable extends TestHiveTableBaseForTrino {
         .skippingTypesCheck()
         .matches(
             "VALUES "
-                + "('id', NULL, NULL, 0e0, NULL, '1', '6'), "
+                + "('id', NULL, NULL, 0e0, NULL, '1', '4'), "
                 + "('op_time', NULL, NULL, 0e0, NULL, '2022-01-01 12:00:00.000000',"
                 + " '2022-01-04 12:00:00.000000'), "
                 + "('op_time_with_zone', NULL, NULL, 0e0, NULL, "
                 + "'2022-01-01 12:00:00.000 UTC', '2022-01-04 12:00:00.000 UTC'), "
-                + "('d$d', NULL, NULL, 0e0, NULL, '100.0', '105.0'), "
-                + "('map_name', 27e0, NULL, 0e0, NULL, NULL, NULL), "
-                + "('array_name', 27e0, NULL, 0e0, NULL, NULL, NULL), "
+                + "('d$d', NULL, NULL, 0e0, NULL, '100.0', '103.0'), "
+                + "('map_name', 24e0, NULL, 0e0, NULL, NULL, NULL), "
+                + "('array_name', 24e0, NULL, 0e0, NULL, NULL, NULL), "
                 + "('struct_name', 0e0, NULL, 0e0, NULL, NULL, NULL), "
-                + "('name', 156e0, NULL, 0e0, NULL, NULL, NULL), "
-                + "(NULL, NULL, NULL, NULL, 9e0, NULL, NULL)");
+                + "('name', 137e0, NULL, 0e0, NULL, NULL, NULL), "
+                + "(NULL, NULL, NULL, NULL, 4e0, NULL, NULL)");
   }
 
   private void assertCommon(String query, List<List<String>> values) {


### PR DESCRIPTION

## Why are the changes needed?

Close #2246.

## Brief change log

- Delete calculating on change store.
- Delete merge stats method.
- Only use base store's stats.

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (**no**)
- If yes, how is the feature documented? (**not applicable**)
