### PR TITLE
[AMORO-2295]: Fix the table property `watermark.base` conflict for keyed-table

### DIFF
--- a/core/src/main/java/com/netease/arctic/table/BasicKeyedTable.java
+++ b/core/src/main/java/com/netease/arctic/table/BasicKeyedTable.java
@@ -18,7 +18,6 @@
 
 package com.netease.arctic.table;
 
-import com.google.common.collect.Maps;
 import com.netease.arctic.ams.api.TableFormat;
 import com.netease.arctic.io.ArcticFileIO;
 import com.netease.arctic.op.KeyedPartitionRewrite;
@@ -41,6 +40,7 @@ import org.apache.iceberg.UpdateProperties;
 import org.apache.iceberg.UpdateSchema;
 import org.apache.iceberg.events.CreateSnapshotEvent;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 
 import java.util.Map;
 

--- a/core/src/main/java/com/netease/arctic/table/BasicKeyedTable.java
+++ b/core/src/main/java/com/netease/arctic/table/BasicKeyedTable.java
@@ -18,6 +18,7 @@
 
 package com.netease.arctic.table;
 
+import com.google.common.collect.Maps;
 import com.netease.arctic.ams.api.TableFormat;
 import com.netease.arctic.io.ArcticFileIO;
 import com.netease.arctic.op.KeyedPartitionRewrite;
@@ -119,22 +120,22 @@ public class BasicKeyedTable implements KeyedTable {
     long changeWatermark = TablePropertyUtil.getTableWatermark(changeTable.properties());
     long baseWatermark = TablePropertyUtil.getTableWatermark(baseTable.properties());
 
-    ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+    Map<String, String> properties = Maps.newHashMap();
     if (changeWatermark > baseWatermark) {
       baseTable
           .properties()
           .forEach(
               (k, v) -> {
                 if (!TableProperties.WATERMARK_TABLE.equals(k)) {
-                  builder.put(k, v);
+                  properties.put(k, v);
                 }
               });
-      builder.put(TableProperties.WATERMARK_TABLE, String.valueOf(changeWatermark));
+      properties.put(TableProperties.WATERMARK_TABLE, String.valueOf(changeWatermark));
     } else {
-      builder.putAll(baseTable.properties());
+      properties.putAll(baseTable.properties());
     }
-    builder.put(TableProperties.WATERMARK_BASE_STORE, String.valueOf(baseWatermark));
-    return builder.build();
+    properties.put(TableProperties.WATERMARK_BASE_STORE, String.valueOf(baseWatermark));
+    return ImmutableMap.copyOf(properties);
   }
 
   @Override


### PR DESCRIPTION
 

## Why are the changes needed?
 

Close #2295.

## Brief change log 

- Using hash map instead of ImmutableMap.Builder for KeyedTable.properties()

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [X] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (  no) 
