### PR TITLE
[AMORO-2324] Use 'DateTimeFormatter' to avoid format parsing exceptions in multithreading

### DIFF
--- a/core/src/main/java/com/netease/arctic/utils/ArcticDataFiles.java
+++ b/core/src/main/java/com/netease/arctic/utils/ArcticDataFiles.java
@@ -38,7 +38,7 @@ public class ArcticDataFiles {
   }
 
   /** return the number of hours away from the epoch, reverse {@link TransformUtil#humanHour} */
-  private static long readHoursData(String asString) {
+  private static Integer readHoursData(String asString) {
     LocalDateTime dateTime = LocalDateTime.parse(asString, FORMAT_HOUR);
     return Math.toIntExact(ChronoUnit.HOURS.between(EPOCH, dateTime));
   }

--- a/core/src/main/java/com/netease/arctic/utils/ArcticDataFiles.java
+++ b/core/src/main/java/com/netease/arctic/utils/ArcticDataFiles.java
@@ -12,22 +12,18 @@ import java.io.UnsupportedEncodingException;
 import java.math.BigDecimal;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.time.Instant;
-import java.time.OffsetDateTime;
+import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
-import java.util.TimeZone;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
 public class ArcticDataFiles {
-  public static final OffsetDateTime EPOCH = Instant.ofEpochSecond(0).atOffset(ZoneOffset.UTC);
-  public static final SimpleDateFormat SDF = new SimpleDateFormat("yyyy-MM-dd-hh");
+  public static final LocalDateTime EPOCH = LocalDateTime.ofEpochSecond(0, 0, ZoneOffset.UTC);
+  private static final DateTimeFormatter FORMAT_HOUR = DateTimeFormatter.ofPattern("yyyy-MM-dd-HH");
   private static final int EPOCH_YEAR = EPOCH.getYear();
   private static final String HIVE_NULL = "__HIVE_DEFAULT_PARTITION__";
   private static final String MONTH_TYPE = "month";
@@ -42,15 +38,9 @@ public class ArcticDataFiles {
   }
 
   /** return the number of hours away from the epoch, reverse {@link TransformUtil#humanHour} */
-  private static Integer readHoursData(String asString) {
-    try {
-      SDF.setTimeZone(TimeZone.getTimeZone("UTC"));
-      Date date = SDF.parse(asString);
-      OffsetDateTime parse = OffsetDateTime.parse(date.toInstant().toString());
-      return Math.toIntExact(ChronoUnit.HOURS.between(EPOCH, parse));
-    } catch (ParseException e) {
-      throw new UnsupportedOperationException("Failed to parse date string:" + asString);
-    }
+  private static long readHoursData(String asString) {
+    LocalDateTime dateTime = LocalDateTime.parse(asString, FORMAT_HOUR);
+    return Math.toIntExact(ChronoUnit.HOURS.between(EPOCH, dateTime));
   }
 
   public static Object fromPartitionString(PartitionField field, Type type, String asString) {

--- a/core/src/test/java/com/netease/arctic/utils/TestArcticDataFiles.java
+++ b/core/src/test/java/com/netease/arctic/utils/TestArcticDataFiles.java
@@ -75,14 +75,40 @@ public class TestArcticDataFiles {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).hour("dt").build();
     PartitionKey partitionKey = new PartitionKey(spec, SCHEMA);
     GenericRecord record = GenericRecord.create(SCHEMA);
+
     InternalRecordWrapper internalRecordWrapper = new InternalRecordWrapper(SCHEMA.asStruct());
+
     partitionKey.partition(
-        internalRecordWrapper.wrap(record.copy("dt", LocalDateTime.parse("2022-11-11T11:00:00"))));
+        internalRecordWrapper.wrap(record.copy("dt", LocalDateTime.parse("2022-11-11T09:30:00"))));
     String partitionPath = spec.partitionToPath(partitionKey);
     StructLike partitionData = ArcticDataFiles.data(spec, partitionPath);
     StructLikeWrapper p1 = StructLikeWrapper.forType(spec.partitionType());
     p1.set(partitionKey);
     StructLikeWrapper p2 = StructLikeWrapper.forType(spec.partitionType());
+    p2.set(partitionData);
+    Assert.assertEquals(p1, p2);
+
+    partitionKey.partition(
+        internalRecordWrapper.wrap(record.copy("dt", LocalDateTime.parse("2022-11-11T12:00:00"))));
+    partitionPath = spec.partitionToPath(partitionKey);
+    partitionData = ArcticDataFiles.data(spec, partitionPath);
+    p1.set(partitionKey);
+    p2.set(partitionData);
+    Assert.assertEquals(p1, p2);
+
+    partitionKey.partition(
+        internalRecordWrapper.wrap(record.copy("dt", LocalDateTime.parse("2022-11-11T15:30:00"))));
+    partitionPath = spec.partitionToPath(partitionKey);
+    partitionData = ArcticDataFiles.data(spec, partitionPath);
+    p1.set(partitionKey);
+    p2.set(partitionData);
+    Assert.assertEquals(p1, p2);
+
+    partitionKey.partition(
+        internalRecordWrapper.wrap(record.copy("dt", LocalDateTime.parse("2022-11-12T00:00:00"))));
+    partitionPath = spec.partitionToPath(partitionKey);
+    partitionData = ArcticDataFiles.data(spec, partitionPath);
+    p1.set(partitionKey);
     p2.set(partitionData);
     Assert.assertEquals(p1, p2);
   }


### PR DESCRIPTION
…ns in multithreading

<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.netease.com/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close #2324 .

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

-Use 'DateTimeFormatter' to avoid format parsing exceptions in multithreading

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
