### PR TITLE
[AMORO-2329]: Miss ChangeStore && PrimaryKeySpec in table detail when creating mixed-iceberg table in InternalCatalog.

### DIFF
--- a/ams/server/src/main/java/com/netease/arctic/server/table/internal/InternalMixedIcebergCreator.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/table/internal/InternalMixedIcebergCreator.java
@@ -98,6 +98,8 @@ public class InternalMixedIcebergCreator extends InternalIcebergCreator {
     metadata
         .getProperties()
         .put(CHANGE_STORE_PREFIX + PROPERTIES_METADATA_LOCATION, changeMetadataFileLocation);
+    metadata.setChangeLocation(changeTableLocation);
+    metadata.setPrimaryKey(keySpec.description());
 
     OutputFile changeStoreFile = io.newOutputFile(changeMetadataFileLocation);
     this.changMetadataFileLocation = changeMetadataFileLocation;

--- a/ams/server/src/test/java/com/netease/arctic/server/TestInternalMixedCatalogService.java
+++ b/ams/server/src/test/java/com/netease/arctic/server/TestInternalMixedCatalogService.java
@@ -18,6 +18,7 @@
 
 package com.netease.arctic.server;
 
+import com.netease.arctic.AmoroTable;
 import com.netease.arctic.ams.api.CatalogMeta;
 import com.netease.arctic.ams.api.TableFormat;
 import com.netease.arctic.ams.api.properties.CatalogMetaProperties;
@@ -157,6 +158,16 @@ public class TestInternalMixedCatalogService extends RestCatalogServiceTestBase 
       // assert load table
       ArcticTable mixedIcebergTable = catalog.loadTable(tableIdentifier);
       Assertions.assertEquals(withPrimary, mixedIcebergTable.isKeyedTable());
+
+      AmoroTable<?> serverTable = serverCatalog.loadTable(database, table);
+      Assertions.assertEquals(TableFormat.MIXED_ICEBERG, serverTable.format());
+      ArcticTable serverMixedIceberg = (ArcticTable) serverTable.originalTable();
+      Assertions.assertEquals(withPrimary, serverMixedIceberg.isKeyedTable());
+      if (withPrimary) {
+        Assertions.assertEquals(
+            keySpec.description(),
+            serverMixedIceberg.asKeyedTable().primaryKeySpec().description());
+      }
 
       // drop table
       catalog.dropTable(tableIdentifier, true);


### PR DESCRIPTION
 
## Why are the changes needed?
 
Close #2329.

## Brief change log 

- Set change table location and primary key spec when create a keyed mixed-iceberg table.

## How was this patch tested?

- [X] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [X] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (no) 
