### PR TITLE
[HOTFIX] limit ams server dist dependencies to runtime scope

### DIFF
--- a/ams/server/pom.xml
+++ b/ams/server/pom.xml
@@ -420,6 +420,7 @@
                             <outputDirectory>
                                 ${project.build.directory}/amoro-ams-server-dependency/lib
                             </outputDirectory>
+                            <includeScope>runtime</includeScope>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
## Why are the changes needed?
Currently, Ams lib contains unnecessary test jars.

## Brief change log
Exclude test jars from ams lib.

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
