### PR TITLE
[AMORO-2415] Print GC date stamps 

### DIFF
--- a/ams/dist/src/main/arctic-bin/bin/ams.sh
+++ b/ams/dist/src/main/arctic-bin/bin/ams.sh
@@ -24,7 +24,7 @@ source ${CURRENT_DIR}/load-config.sh
 
 
 
-JAVA_OPTS="-server -Xloggc:$AMORO_LOG_DIR/gc.log -XX:+IgnoreUnrecognizedVMOptions -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=10M \
+JAVA_OPTS="-server -Xloggc:$AMORO_LOG_DIR/gc.log -XX:+PrintGCDateStamps -XX:+IgnoreUnrecognizedVMOptions -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=10M \
 -Xms${JVM_XMS_CONFIG}m -Xmx${JVM_XMX_CONFIG}m \
 -verbose:gc -XX:+PrintGCDetails \
 -Dcom.sun.management.jmxremote \


### PR DESCRIPTION
## Why are the changes needed?
Close #2415.

## Brief change log

- Add '-XX:+PrintGCDateStamps' to ams.sh.

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable)
