### PR TITLE
[AMORO-2441] Fix `TableEntriesScan` when no file format is specified in the file name

### DIFF
--- a/core/src/main/java/com/netease/arctic/scan/TableEntriesScan.java
+++ b/core/src/main/java/com/netease/arctic/scan/TableEntriesScan.java
@@ -26,6 +26,7 @@ import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.DataTask;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileContent;
+import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.FileMetadata;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.HasTableOperations;
@@ -309,11 +310,13 @@ public class TableEntriesScan {
     String filePath = fileRecord.get(dataFileFieldIndex(DataFile.FILE_PATH.name()), String.class);
     Long fileSize = fileRecord.get(dataFileFieldIndex(DataFile.FILE_SIZE.name()), Long.class);
     Long recordCount = fileRecord.get(dataFileFieldIndex(DataFile.RECORD_COUNT.name()), Long.class);
+    FileFormat format = FileFormat.fromFileName(filePath);
     DataFiles.Builder builder =
         DataFiles.builder(table.spec())
             .withPath(filePath)
             .withFileSizeInBytes(fileSize)
-            .withRecordCount(recordCount);
+            .withRecordCount(recordCount)
+            .withFormat(format != null ? format : FileFormat.PARQUET);
     if (needMetrics()) {
       builder.withMetrics(buildMetrics(fileRecord));
     }
@@ -329,11 +332,13 @@ public class TableEntriesScan {
     String filePath = fileRecord.get(dataFileFieldIndex(DataFile.FILE_PATH.name()), String.class);
     Long fileSize = fileRecord.get(dataFileFieldIndex(DataFile.FILE_SIZE.name()), Long.class);
     Long recordCount = fileRecord.get(dataFileFieldIndex(DataFile.RECORD_COUNT.name()), Long.class);
+    FileFormat format = FileFormat.fromFileName(filePath);
     FileMetadata.Builder builder =
         FileMetadata.deleteFileBuilder(table.spec())
             .withPath(filePath)
             .withFileSizeInBytes(fileSize)
-            .withRecordCount(recordCount);
+            .withRecordCount(recordCount)
+            .withFormat(format != null ? format : FileFormat.PARQUET);
     if (needMetrics()) {
       builder.withMetrics(buildMetrics(fileRecord));
     }

--- a/core/src/main/java/com/netease/arctic/scan/TableEntriesScan.java
+++ b/core/src/main/java/com/netease/arctic/scan/TableEntriesScan.java
@@ -310,13 +310,13 @@ public class TableEntriesScan {
     String filePath = fileRecord.get(dataFileFieldIndex(DataFile.FILE_PATH.name()), String.class);
     Long fileSize = fileRecord.get(dataFileFieldIndex(DataFile.FILE_SIZE.name()), Long.class);
     Long recordCount = fileRecord.get(dataFileFieldIndex(DataFile.RECORD_COUNT.name()), Long.class);
-    FileFormat format = FileFormat.fromFileName(filePath);
+    String format = fileRecord.get(dataFileFieldIndex(DataFile.FILE_FORMAT.name()), String.class);
     DataFiles.Builder builder =
         DataFiles.builder(table.spec())
             .withPath(filePath)
             .withFileSizeInBytes(fileSize)
             .withRecordCount(recordCount)
-            .withFormat(format != null ? format : FileFormat.PARQUET);
+            .withFormat(FileFormat.fromString(format));
     if (needMetrics()) {
       builder.withMetrics(buildMetrics(fileRecord));
     }
@@ -332,13 +332,13 @@ public class TableEntriesScan {
     String filePath = fileRecord.get(dataFileFieldIndex(DataFile.FILE_PATH.name()), String.class);
     Long fileSize = fileRecord.get(dataFileFieldIndex(DataFile.FILE_SIZE.name()), Long.class);
     Long recordCount = fileRecord.get(dataFileFieldIndex(DataFile.RECORD_COUNT.name()), Long.class);
-    FileFormat format = FileFormat.fromFileName(filePath);
+    String format = fileRecord.get(dataFileFieldIndex(DataFile.FILE_FORMAT.name()), String.class);
     FileMetadata.Builder builder =
         FileMetadata.deleteFileBuilder(table.spec())
             .withPath(filePath)
             .withFileSizeInBytes(fileSize)
             .withRecordCount(recordCount)
-            .withFormat(format != null ? format : FileFormat.PARQUET);
+            .withFormat(FileFormat.fromString(format));
     if (needMetrics()) {
       builder.withMetrics(buildMetrics(fileRecord));
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.netease.com/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close #2441 .

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- fix TableEntriesScan without format suffix

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / **no**)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
