### PR TITLE
[HOTFIX] Remove Trino module's Checkstyle

### DIFF
--- a/mixed/trino/pom.xml
+++ b/mixed/trino/pom.xml
@@ -596,13 +596,6 @@
                 </configuration>
             </plugin>
 
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-checkstyle-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
 
             <plugin>
                 <groupId>com.diffplug.spotless</groupId>


### PR DESCRIPTION

## Why are the changes needed?

We forgot to remove trino's Checkstyle in https://github.com/NetEase/amoro/pull/2175.

## Brief change log

- remove trino's Checkstyle.

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable)
