### PR TITLE
[AMORO-2466] Fix bug #2466 spark query the mix_hive table will throw out exception

### DIFF
--- a/ams/server/src/main/java/com/netease/arctic/server/TableManagementService.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/TableManagementService.java
@@ -98,7 +98,8 @@ public class TableManagementService implements ArcticTableMetastore.Iface {
   @Override
   public TableMeta getTable(TableIdentifier tableIdentifier) {
     TableMetadata tableMetadata = tableService.loadTableMetadata(tableIdentifier);
-    if (!InternalTableUtil.isLegacyMixedIceberg(tableMetadata)) {
+    if (tableMetadata.getFormat() == TableFormat.MIXED_ICEBERG
+        && !InternalTableUtil.isLegacyMixedIceberg(tableMetadata)) {
       throw new IllegalArgumentException(
           "The table "
               + tableIdentifier.toString()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.netease.com/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close #2466.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- correct the check logic for legacy MixedIceberg to avoid throw out exception when quering the mix-hive format table.

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / **no**)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
