### PR TITLE
[Hotfix] Fix artifactId of shade plugin

### DIFF
--- a/mixed/flink/v1.15/flink/pom.xml
+++ b/mixed/flink/v1.15/flink/pom.xml
@@ -31,6 +31,8 @@
     <name>Amoro Project Mixed Format Flink 1.15</name>
     <url>https://amoro.netease.com</url>
 
+    <packaging>jar</packaging>
+
     <properties>
         <kafka.version>2.8.1</kafka.version>
         <assertj.version>3.21.0</assertj.version>
@@ -80,7 +82,7 @@
                         <configuration>
                             <artifactSet>
                                 <includes combine.children="append">
-                                    <include>com.netease.amoro:flink-common</include>
+                                    <include>com.netease.amoro:amoro-mixed-flink-common</include>
                                 </includes>
                             </artifactSet>
                         </configuration>

--- a/mixed/flink/v1.16/flink/pom.xml
+++ b/mixed/flink/v1.16/flink/pom.xml
@@ -82,7 +82,7 @@
                         <configuration>
                             <artifactSet>
                                 <includes combine.children="append">
-                                    <include>com.netease.amoro:flink-common</include>
+                                    <include>com.netease.amoro:amoro-mixed-flink-common</include>
                                 </includes>
                             </artifactSet>
                         </configuration>

--- a/mixed/flink/v1.17/flink/pom.xml
+++ b/mixed/flink/v1.17/flink/pom.xml
@@ -82,7 +82,7 @@
                         <configuration>
                             <artifactSet>
                                 <includes combine.children="append">
-                                    <include>com.netease.amoro:flink-common</include>
+                                    <include>com.netease.amoro:amoro-mixed-flink-common</include>
                                 </includes>
                             </artifactSet>
                         </configuration>


### PR DESCRIPTION
## Why are the changes needed?

`artifactId` has been modified via #2374 

## Brief change log

- Fix artifactId from `flink-common` to `amoro-mixed-flink-common`

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / **no**)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
