### PR TITLE
[AMORO-2473] When HMS restarts, accessing the Hive table should be retried instead of throwing an exception directly

### DIFF
--- a/mixed/hive/src/main/java/com/netease/arctic/hive/ArcticHiveClientPool.java
+++ b/mixed/hive/src/main/java/com/netease/arctic/hive/ArcticHiveClientPool.java
@@ -31,6 +31,8 @@ import org.apache.thrift.transport.TTransportException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.SocketException;
+
 /**
  * Extended implementation of {@link ClientPoolImpl} with {@link TableMetaStore} to support
  * authenticated hive cluster.
@@ -113,7 +115,8 @@ public class ArcticHiveClientPool extends ClientPoolImpl<HMSClient, TException> 
         || (e != null
             && e instanceof MetaException
             && e.getMessage()
-                .contains("Got exception: org.apache.thrift.transport.TTransportException"));
+                .contains("Got exception: org.apache.thrift.transport.TTransportException"))
+        || e instanceof SocketException;
   }
 
   @Override


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.netease.com/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close #2473 .

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- add SocketException to hive connect exception

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? ( no)
- If yes, how is the feature documented? (not documented)
