### PR TITLE
[AMORO-2488] Respect Iceberg GC table properties

### DIFF
--- a/ams/server/src/main/java/com/netease/arctic/server/table/DataExpirationConfig.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/table/DataExpirationConfig.java
@@ -161,13 +161,17 @@ public class DataExpirationConfig {
   }
 
   public static DataExpirationConfig parse(Map<String, String> properties) {
+    boolean gcEnabled =
+        CompatiblePropertyUtil.propertyAsBoolean(
+            properties, org.apache.iceberg.TableProperties.GC_ENABLED, true);
     DataExpirationConfig config =
         new DataExpirationConfig()
             .setEnabled(
-                CompatiblePropertyUtil.propertyAsBoolean(
-                    properties,
-                    TableProperties.ENABLE_DATA_EXPIRATION,
-                    TableProperties.ENABLE_DATA_EXPIRATION_DEFAULT))
+                gcEnabled
+                    && CompatiblePropertyUtil.propertyAsBoolean(
+                        properties,
+                        TableProperties.ENABLE_DATA_EXPIRATION,
+                        TableProperties.ENABLE_DATA_EXPIRATION_DEFAULT))
             .setExpirationLevel(
                 ExpireLevel.fromString(
                     CompatiblePropertyUtil.propertyAsString(

--- a/ams/server/src/main/java/com/netease/arctic/server/table/TableConfiguration.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/table/TableConfiguration.java
@@ -154,12 +154,16 @@ public class TableConfiguration {
   }
 
   public static TableConfiguration parseConfig(Map<String, String> properties) {
+    boolean gcEnabled =
+        CompatiblePropertyUtil.propertyAsBoolean(
+            properties, org.apache.iceberg.TableProperties.GC_ENABLED, true);
     return new TableConfiguration()
         .setExpireSnapshotEnabled(
-            CompatiblePropertyUtil.propertyAsBoolean(
-                properties,
-                TableProperties.ENABLE_TABLE_EXPIRE,
-                TableProperties.ENABLE_TABLE_EXPIRE_DEFAULT))
+            gcEnabled
+                && CompatiblePropertyUtil.propertyAsBoolean(
+                    properties,
+                    TableProperties.ENABLE_TABLE_EXPIRE,
+                    TableProperties.ENABLE_TABLE_EXPIRE_DEFAULT))
         .setSnapshotTTLMinutes(
             CompatiblePropertyUtil.propertyAsLong(
                 properties,
@@ -171,20 +175,22 @@ public class TableConfiguration {
                 TableProperties.CHANGE_DATA_TTL,
                 TableProperties.CHANGE_DATA_TTL_DEFAULT))
         .setCleanOrphanEnabled(
-            CompatiblePropertyUtil.propertyAsBoolean(
-                properties,
-                TableProperties.ENABLE_ORPHAN_CLEAN,
-                TableProperties.ENABLE_ORPHAN_CLEAN_DEFAULT))
+            gcEnabled
+                && CompatiblePropertyUtil.propertyAsBoolean(
+                    properties,
+                    TableProperties.ENABLE_ORPHAN_CLEAN,
+                    TableProperties.ENABLE_ORPHAN_CLEAN_DEFAULT))
         .setOrphanExistingMinutes(
             CompatiblePropertyUtil.propertyAsLong(
                 properties,
                 TableProperties.MIN_ORPHAN_FILE_EXISTING_TIME,
                 TableProperties.MIN_ORPHAN_FILE_EXISTING_TIME_DEFAULT))
         .setDeleteDanglingDeleteFilesEnabled(
-            CompatiblePropertyUtil.propertyAsBoolean(
-                properties,
-                TableProperties.ENABLE_DANGLING_DELETE_FILES_CLEAN,
-                TableProperties.ENABLE_DANGLING_DELETE_FILES_CLEAN_DEFAULT))
+            gcEnabled
+                && CompatiblePropertyUtil.propertyAsBoolean(
+                    properties,
+                    TableProperties.ENABLE_DANGLING_DELETE_FILES_CLEAN,
+                    TableProperties.ENABLE_DANGLING_DELETE_FILES_CLEAN_DEFAULT))
         .setOptimizingConfig(OptimizingConfig.parseOptimizingConfig(properties))
         .setExpiringDataConfig(DataExpirationConfig.parse(properties))
         .setTagConfiguration(TagConfiguration.parse(properties));

--- a/ams/server/src/test/java/com/netease/arctic/server/optimizing/maintainer/TestDataExpire.java
+++ b/ams/server/src/test/java/com/netease/arctic/server/optimizing/maintainer/TestDataExpire.java
@@ -463,6 +463,44 @@ public class TestDataExpire extends ExecutorTestBase {
     testFileLevel();
   }
 
+  @Test
+  public void testGcDisabled() {
+    ArcticTable testTable = getArcticTable();
+    testTable.updateProperties().set("gc.enabled", "false").commit();
+
+    ArrayList<Record> baseRecords =
+        Lists.newArrayList(
+            createRecord(1, "111", parseMillis("2022-01-01T12:00:00"), "2022-01-01T12:00:00"));
+    OptimizingTestHelpers.appendBase(
+        testTable, tableTestHelper().writeBaseStore(testTable, 0, baseRecords, false));
+
+    CloseableIterable<TableFileScanHelper.FileScanResult> scan;
+    if (isKeyedTable()) {
+      scan = buildKeyedFileScanHelper().scan();
+    } else {
+      scan = getTableFileScanHelper().scan();
+    }
+    assertScanResult(scan, 1, 0);
+
+    DataExpirationConfig config = new DataExpirationConfig(testTable);
+    MixedTableMaintainer mixedTableMaintainer = new MixedTableMaintainer(getArcticTable());
+    mixedTableMaintainer.expireDataFrom(
+        config,
+        LocalDateTime.parse("2024-01-01T00:00:00.000")
+            .atZone(
+                IcebergTableMaintainer.getDefaultZoneId(
+                    testTable.schema().findField(config.getExpirationField())))
+            .toInstant());
+
+    CloseableIterable<TableFileScanHelper.FileScanResult> scanAfterExpire;
+    if (isKeyedTable()) {
+      scanAfterExpire = buildKeyedFileScanHelper().scan();
+    } else {
+      scanAfterExpire = getTableFileScanHelper().scan();
+    }
+    assertScanResult(scanAfterExpire, 0, 0);
+  }
+
   protected Record createRecord(int id, String name, long ts, String opTime) {
     Object time;
     Schema schema = getArcticTable().schema();


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.netease.com/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?

Close #2488.

## Brief change log

- Exclude table with `gc.enable` = `false`  from table data cleanups.

## How was this patch tested?

- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
