### PR TITLE
[AMORO-2497] [Flink]: Support for serialization and deserialization thread-safe in lookup JOIN

### DIFF
--- a/mixed/flink/flink-common/src/main/java/com/netease/arctic/flink/lookup/BinaryRowDataSerializerWrapper.java
+++ b/mixed/flink/flink-common/src/main/java/com/netease/arctic/flink/lookup/BinaryRowDataSerializerWrapper.java
@@ -33,9 +33,9 @@ import java.io.Serializable;
 
 /**
  * This is a wrapper for {@link BinaryRowDataSerializer}. It is used to serialize and deserialize
- * RowData.
+ * RowData. And serialize and deserialize operations are not thread-safe.
  */
-public class BinaryRowDataSerializerWrapper implements Serializable {
+public class BinaryRowDataSerializerWrapper implements Serializable, Cloneable {
 
   private static final long serialVersionUID = 1L;
   protected BinaryRowDataSerializer serializer;
@@ -72,5 +72,10 @@ public class BinaryRowDataSerializerWrapper implements Serializable {
     }
     inputView.setBuffer(recordBytes);
     return serializer.deserialize(inputView);
+  }
+
+  @Override
+  public BinaryRowDataSerializerWrapper clone() {
+    return new BinaryRowDataSerializerWrapper(schema);
   }
 }

--- a/mixed/flink/flink-common/src/main/java/com/netease/arctic/flink/lookup/RocksDBRecordState.java
+++ b/mixed/flink/flink-common/src/main/java/com/netease/arctic/flink/lookup/RocksDBRecordState.java
@@ -140,10 +140,17 @@ public class RocksDBRecordState extends RocksDBCacheState<byte[]> {
   }
 
   private byte[] serializeValue(RowData value) throws IOException {
-    return valueSerializer.serialize(value);
+    return valueSerializer().serialize(value);
   }
 
   private RowData deserializeValue(byte[] recordBytes) throws IOException {
-    return valueSerializer.deserialize(recordBytes);
+    return valueSerializer().deserialize(recordBytes);
+  }
+
+  private BinaryRowDataSerializerWrapper valueSerializer() {
+    if (valueSerializerThreadLocal.get() == null) {
+      valueSerializerThreadLocal.set(valueSerializer.clone());
+    }
+    return valueSerializerThreadLocal.get();
   }
 }


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.netease.com/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close #2497.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- Using `ThreadLocal` API to make the `BinaryRowDataSerializerWrapper` utility thread-safe.

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no) no
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
