### PR TITLE
[AMORO-2505] Change the default docker image version to 'latest' in the startup script

### DIFF
--- a/docker/demo-cluster.sh
+++ b/docker/demo-cluster.sh
@@ -18,7 +18,8 @@
 #
 
 
-AMORO_TAG=master-snapshot
+# default to use the last built image when no specified tag given
+AMORO_TAG=latest
 
 
 CURRENT_DIR="$( cd "$(dirname "$0")" ; pwd -P )"


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.netease.com/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close #2505 .

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- Change the default docker image version to 'latest' in the startup script, the 'latest' version in docker means that the last image has been built without a specified tag.


## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

Before the change
![image](https://github.com/NetEase/amoro/assets/1425623/6da279ef-f889-4146-a6c5-4f8d9b7b734e)
After the change 
![image](https://github.com/NetEase/amoro/assets/1425623/771f3fcc-94c6-4c05-8690-13965a32e5d0)

## Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable)

cc @zhoujinsong @baiyangtx 