### PR TITLE
[AMORO-2522] Delete the dispose of DefaultOptimizingService in TableRuntimeHandlerImpl

### DIFF
--- a/ams/server/src/main/java/com/netease/arctic/server/DefaultOptimizingService.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/DefaultOptimizingService.java
@@ -457,9 +457,7 @@ public class DefaultOptimizingService extends StatedPersistentBase
     }
 
     @Override
-    protected void doDispose() {
-      DefaultOptimizingService.this.dispose();
-    }
+    protected void doDispose() {}
   }
 
   private class OptimizerKeepingTask implements Delayed {


### PR DESCRIPTION

## Why are the changes needed?

Close #2522.

## Brief change log

- Delete the dispose of DefaultOptimizingService in TableRuntimeHandlerImpl

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / **no**)
- If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
