### PR TITLE
[AMORO-2345] Support UnifiedCatalog to contain Paimon format table in Flink Engine

### DIFF
--- a/core/src/test/java/com/netease/arctic/formats/AmoroCatalogTestHelper.java
+++ b/core/src/test/java/com/netease/arctic/formats/AmoroCatalogTestHelper.java
@@ -85,4 +85,7 @@ public interface AmoroCatalogTestHelper<T> {
 
   /** Create a table. The schema, properties, etc. of a table depend on its implementation. */
   void createTable(String db, String tableName) throws Exception;
+
+  /** Create database. */
+  void createDatabase(String database) throws Exception;
 }

--- a/core/src/test/java/com/netease/arctic/formats/IcebergHadoopCatalogTestHelper.java
+++ b/core/src/test/java/com/netease/arctic/formats/IcebergHadoopCatalogTestHelper.java
@@ -129,6 +129,15 @@ public class IcebergHadoopCatalogTestHelper extends AbstractFormatCatalogTestHel
     catalog.createTable(TableIdentifier.of(db, tableName), schema, spec, properties);
   }
 
+  @Override
+  public void createDatabase(String database) {
+    Catalog catalog = originalCatalog();
+    if (catalog instanceof SupportsNamespaces) {
+      Namespace ns = Namespace.of(database);
+      ((SupportsNamespaces) catalog).createNamespace(ns);
+    }
+  }
+
   public static IcebergHadoopCatalogTestHelper defaultHelper() {
     return new IcebergHadoopCatalogTestHelper("test_iceberg_catalog", new HashMap<>());
   }

--- a/core/src/test/java/com/netease/arctic/formats/MixedIcebergHadoopCatalogTestHelper.java
+++ b/core/src/test/java/com/netease/arctic/formats/MixedIcebergHadoopCatalogTestHelper.java
@@ -122,6 +122,12 @@ public class MixedIcebergHadoopCatalogTestHelper
         .create();
   }
 
+  @Override
+  public void createDatabase(String database) {
+    ArcticCatalog catalog = originalCatalog();
+    catalog.createDatabase(database);
+  }
+
   public static MixedIcebergHadoopCatalogTestHelper defaultHelper() {
     return new MixedIcebergHadoopCatalogTestHelper("test_mixed_iceberg_catalog", new HashMap<>());
   }

--- a/core/src/test/java/com/netease/arctic/formats/PaimonHadoopCatalogTestHelper.java
+++ b/core/src/test/java/com/netease/arctic/formats/PaimonHadoopCatalogTestHelper.java
@@ -18,6 +18,7 @@
 
 package com.netease.arctic.formats;
 
+import com.netease.arctic.AlreadyExistsException;
 import com.netease.arctic.AmoroCatalog;
 import com.netease.arctic.ams.api.TableFormat;
 import com.netease.arctic.formats.paimon.PaimonCatalogFactory;
@@ -125,6 +126,15 @@ public class PaimonHadoopCatalogTestHelper extends AbstractFormatCatalogTestHelp
       catalog.createTable(Identifier.create(db, tableName), schema, false);
     } catch (Exception e) {
       throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public void createDatabase(String database) throws Exception {
+    try (Catalog catalog = originalCatalog()) {
+      catalog.createDatabase(database, false);
+    } catch (Catalog.DatabaseAlreadyExistException e) {
+      throw new AlreadyExistsException(e);
     }
   }
 

--- a/mixed/flink/flink-common/pom.xml
+++ b/mixed/flink/flink-common/pom.xml
@@ -84,6 +84,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-flink-common</artifactId>
+            <version>${paimon.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>com.netease.amoro</groupId>

--- a/mixed/flink/flink-common/src/main/java/com/netease/arctic/flink/catalog/FlinkUnifiedCatalog.java
+++ b/mixed/flink/flink-common/src/main/java/com/netease/arctic/flink/catalog/FlinkUnifiedCatalog.java
@@ -31,6 +31,7 @@ import com.netease.arctic.ams.api.TableFormat;
 import com.netease.arctic.ams.api.client.ArcticThriftUrl;
 import com.netease.arctic.flink.catalog.factories.iceberg.IcebergFlinkCatalogFactory;
 import com.netease.arctic.flink.catalog.factories.mixed.MixedCatalogFactory;
+import com.netease.arctic.flink.catalog.factories.paimon.PaimonFlinkCatalogFactory;
 import com.netease.arctic.flink.table.AmoroDynamicTableFactory;
 import com.netease.arctic.table.TableIdentifier;
 import org.apache.flink.configuration.Configuration;
@@ -446,6 +447,11 @@ public class FlinkUnifiedCatalog extends AbstractCatalog {
         break;
       case ICEBERG:
         catalogFactory = new IcebergFlinkCatalogFactory(hadoopConf);
+        break;
+      case PAIMON:
+        catalogFactory =
+            new PaimonFlinkCatalogFactory(
+                unifiedCatalog.properties(), unifiedCatalog.metastoreType());
         break;
       default:
         throw new UnsupportedOperationException(

--- a/mixed/flink/flink-common/src/main/java/com/netease/arctic/flink/catalog/factories/FlinkUnifiedCatalogFactory.java
+++ b/mixed/flink/flink-common/src/main/java/com/netease/arctic/flink/catalog/factories/FlinkUnifiedCatalogFactory.java
@@ -44,7 +44,11 @@ import java.util.Set;
 public class FlinkUnifiedCatalogFactory implements CatalogFactory {
 
   public static final Set<TableFormat> SUPPORTED_FORMATS =
-      Sets.newHashSet(TableFormat.MIXED_ICEBERG, TableFormat.MIXED_HIVE, TableFormat.ICEBERG);
+      Sets.newHashSet(
+          TableFormat.MIXED_ICEBERG,
+          TableFormat.MIXED_HIVE,
+          TableFormat.ICEBERG,
+          TableFormat.PAIMON);
 
   @Override
   public String factoryIdentifier() {

--- a/mixed/flink/flink-common/src/main/java/com/netease/arctic/flink/catalog/factories/paimon/PaimonFlinkCatalogFactory.java
+++ b/mixed/flink/flink-common/src/main/java/com/netease/arctic/flink/catalog/factories/paimon/PaimonFlinkCatalogFactory.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.flink.catalog.factories.paimon;
+
+import com.netease.arctic.ams.api.properties.CatalogMetaProperties;
+import org.apache.paimon.catalog.FileSystemCatalogFactory;
+import org.apache.paimon.flink.FlinkCatalog;
+import org.apache.paimon.flink.FlinkCatalogFactory;
+import org.apache.paimon.options.CatalogOptions;
+
+import java.util.Map;
+
+/** Creating Paimon FlinkCatalogFactory with properties which stored in the AMS */
+public class PaimonFlinkCatalogFactory extends FlinkCatalogFactory {
+  private final Map<String, String> options;
+  private final String metastoreType;
+
+  public PaimonFlinkCatalogFactory(Map<String, String> options, String metastoreType) {
+    this.options = options;
+    this.metastoreType = metastoreType;
+  }
+
+  @Override
+  public FlinkCatalog createCatalog(Context context) {
+    context.getOptions().putAll(options);
+    addMetastoreType(context);
+    return super.createCatalog(context);
+  }
+
+  private void addMetastoreType(Context context) {
+    String type;
+    if (CatalogMetaProperties.CATALOG_TYPE_HADOOP.equalsIgnoreCase(metastoreType)) {
+      type = FileSystemCatalogFactory.IDENTIFIER;
+    } else {
+      type = metastoreType;
+    }
+    context.getOptions().put(CatalogOptions.METASTORE.key(), type);
+  }
+}

--- a/mixed/flink/flink-common/src/test/java/com/netease/arctic/flink/catalog/FlinkAmoroCatalogITCase.java
+++ b/mixed/flink/flink-common/src/test/java/com/netease/arctic/flink/catalog/FlinkAmoroCatalogITCase.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.flink.catalog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.netease.arctic.flink.table.AmoroCatalogITCaseBase;
+import com.netease.arctic.formats.AmoroCatalogTestHelper;
+import com.netease.arctic.formats.PaimonHadoopCatalogTestHelper;
+import com.netease.arctic.formats.paimon.PaimonTable;
+import com.netease.arctic.hive.TestHMS;
+import com.netease.arctic.hive.formats.PaimonHiveCatalogTestHelper;
+import org.apache.flink.table.api.TableResult;
+import org.apache.flink.table.catalog.AbstractCatalog;
+import org.apache.flink.table.catalog.Catalog;
+import org.apache.flink.table.catalog.CatalogBaseTable;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.types.Row;
+import org.apache.paimon.table.FileStoreTable;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+/** ITCase for Flink UnifiedCatalog based on AmoroCatalogTestBase */
+@RunWith(value = Parameterized.class)
+public class FlinkAmoroCatalogITCase extends AmoroCatalogITCaseBase {
+  static final TestHMS TEST_HMS = new TestHMS();
+  AbstractCatalog flinkCatalog;
+
+  public FlinkAmoroCatalogITCase(AmoroCatalogTestHelper<?> catalogTestHelper) {
+    super(catalogTestHelper);
+  }
+
+  @Parameterized.Parameters(name = "{0}")
+  public static Object[] parameters() {
+    return new Object[] {
+      PaimonHiveCatalogTestHelper.defaultHelper(), PaimonHadoopCatalogTestHelper.defaultHelper()
+    };
+  }
+
+  @BeforeClass
+  public static void beforeAll() throws Exception {
+    TEST_HMS.before();
+  }
+
+  @Before
+  public void setup() throws Exception {
+    createDatabase();
+    createTable();
+    String catalog = "unified_catalog";
+    exec(
+        "CREATE CATALOG %s WITH ('type'='unified', 'metastore.url'='%s')",
+        catalog, getCatalogUrl());
+    exec("USE CATALOG %s", catalog);
+    exec("USE %s", TEST_DB_NAME);
+    Optional<Catalog> catalogOptional = getTableEnv().getCatalog(catalog);
+    assertTrue(catalogOptional.isPresent());
+    flinkCatalog = (AbstractCatalog) catalogOptional.get();
+    assertEquals(catalog, flinkCatalog.getName());
+  }
+
+  @After
+  public void teardown() {
+    TEST_HMS.after();
+    if (flinkCatalog != null) {
+      flinkCatalog.close();
+    }
+  }
+
+  public void createDatabase() {
+    try {
+      catalogTestHelper.createDatabase(TEST_DB_NAME);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public void createTable() {
+    try {
+      catalogTestHelper.createTable(TEST_DB_NAME, TEST_TABLE_NAME);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Test
+  public void testTableExists() throws Exception {
+    CatalogBaseTable catalogBaseTable =
+        flinkCatalog.getTable(new ObjectPath(TEST_DB_NAME, TEST_TABLE_NAME));
+    assertNotNull(catalogBaseTable);
+    PaimonTable paimonTable =
+        (PaimonTable) catalogTestHelper.amoroCatalog().loadTable(TEST_DB_NAME, TEST_TABLE_NAME);
+    FileStoreTable originalPaimonTable = (FileStoreTable) paimonTable.originalTable();
+    assertEquals(
+        originalPaimonTable.schema().fields().size(),
+        catalogBaseTable.getUnresolvedSchema().getColumns().size());
+  }
+
+  @Test
+  public void testInsertAndQuery() throws Exception {
+    exec("INSERT INTO %s SELECT 1, 'Lily', 1234567890", TEST_TABLE_NAME);
+    TableResult tableResult =
+        exec("select * from %s /*+OPTIONS('monitor-interval'='1s')*/ ", TEST_TABLE_NAME);
+
+    tableResult.await(30, TimeUnit.SECONDS);
+
+    Row actualRow = tableResult.collect().next();
+    assertEquals(Row.of(1, "Lily", 1234567890).toString(), actualRow.toString());
+  }
+
+  @Test
+  public void testSwitchCurrentCatalog() {
+    String memCatalog = "mem_catalog";
+    exec("create catalog %s with('type'='generic_in_memory')", memCatalog);
+    exec(
+        "create table %s.`default`.datagen_table(\n"
+            + "    a int,\n"
+            + "    b varchar"
+            + ") with(\n"
+            + "    'connector'='datagen',\n"
+            + "    'number-of-rows'='1'\n"
+            + ")",
+        memCatalog);
+    TableResult tableResult = exec("select * from mem_catalog.`default`.datagen_table");
+    assertNotNull(tableResult.collect().next());
+    exec("use catalog %s", memCatalog);
+    tableResult = exec("select * from datagen_table");
+    assertNotNull(tableResult.collect().next());
+  }
+}

--- a/mixed/flink/flink-common/src/test/java/com/netease/arctic/flink/catalog/FlinkCatalogContext.java
+++ b/mixed/flink/flink-common/src/test/java/com/netease/arctic/flink/catalog/FlinkCatalogContext.java
@@ -72,7 +72,11 @@ public class FlinkCatalogContext {
         Arguments.of(
             initFlinkCatalog(TableFormat.ICEBERG),
             generateFlinkTable(TableFormat.ICEBERG.toString()),
-            TableFormat.ICEBERG));
+            TableFormat.ICEBERG),
+        Arguments.of(
+            initFlinkCatalog(TableFormat.PAIMON),
+            generateFlinkTable(TableFormat.PAIMON.toString()),
+            TableFormat.PAIMON));
   }
 
   static ResolvedCatalogTable generateFlinkTable(String tableFormat) {

--- a/mixed/flink/flink-common/src/test/java/com/netease/arctic/flink/catalog/TestFlinkUnifiedCatalogs.java
+++ b/mixed/flink/flink-common/src/test/java/com/netease/arctic/flink/catalog/TestFlinkUnifiedCatalogs.java
@@ -98,8 +98,12 @@ class TestFlinkUnifiedCatalogs {
       flinkUnifiedCatalog.alterDatabase(
           "default", new CatalogDatabaseImpl(Collections.emptyMap(), "default"), false);
     } catch (UnsupportedOperationException e) {
-      // Mixed-format and Iceberg catalog does not support altering database.
-      if (!tableFormat.in(TableFormat.MIXED_HIVE, TableFormat.MIXED_ICEBERG, TableFormat.ICEBERG)) {
+      // Mixed-format,Iceberg and paimon catalog does not support altering database.
+      if (!tableFormat.in(
+          TableFormat.MIXED_HIVE,
+          TableFormat.MIXED_ICEBERG,
+          TableFormat.ICEBERG,
+          TableFormat.PAIMON)) {
         throw e;
       }
     }

--- a/mixed/flink/flink-common/src/test/java/com/netease/arctic/flink/table/AmoroCatalogITCaseBase.java
+++ b/mixed/flink/flink-common/src/test/java/com/netease/arctic/flink/table/AmoroCatalogITCaseBase.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netease.arctic.flink.table;
+
+import static org.apache.flink.table.api.config.TableConfigOptions.TABLE_DYNAMIC_TABLE_OPTIONS_ENABLED;
+
+import com.netease.arctic.TestAms;
+import com.netease.arctic.formats.AmoroCatalogTestBase;
+import com.netease.arctic.formats.AmoroCatalogTestHelper;
+import com.netease.arctic.hive.TestHMS;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.runtime.state.filesystem.FsStateBackend;
+import org.apache.flink.streaming.api.CheckpointingMode;
+import org.apache.flink.streaming.api.environment.CheckpointConfig;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.TableResult;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.iceberg.flink.MiniClusterResource;
+import org.junit.ClassRule;
+
+import java.io.IOException;
+
+public class AmoroCatalogITCaseBase extends AmoroCatalogTestBase {
+  static final TestHMS TEST_HMS = new TestHMS();
+  public static final String TEST_DB_NAME = "test_db";
+  public static final String TEST_TABLE_NAME = "test_table";
+
+  @ClassRule
+  public static final MiniClusterWithClientResource MINI_CLUSTER_RESOURCE =
+      MiniClusterResource.createWithClassloaderCheckDisabled();
+
+  @ClassRule public static TestAms TEST_AMS = new TestAms();
+
+  private volatile StreamTableEnvironment tEnv = null;
+  private volatile StreamExecutionEnvironment env = null;
+
+  public AmoroCatalogITCaseBase(AmoroCatalogTestHelper<?> catalogTestHelper) {
+    super(catalogTestHelper);
+  }
+
+  @Override
+  public void setupCatalog() throws IOException {
+    super.setupCatalog();
+    catalogTestHelper.initHiveConf(TEST_HMS.getHiveConf());
+    TEST_AMS.getAmsHandler().createCatalog(catalogTestHelper.getCatalogMeta());
+  }
+
+  protected String getCatalogUrl() {
+    return TEST_AMS.getServerUrl() + "/" + catalogTestHelper.getCatalogMeta().getCatalogName();
+  }
+
+  protected TableResult exec(String query, Object... args) {
+    return exec(getTableEnv(), query, args);
+  }
+
+  protected static TableResult exec(TableEnvironment env, String query, Object... args) {
+    return env.executeSql(String.format(query, args));
+  }
+
+  protected StreamTableEnvironment getTableEnv() {
+    if (tEnv == null) {
+      synchronized (this) {
+        if (tEnv == null) {
+          this.tEnv =
+              StreamTableEnvironment.create(
+                  getEnv(), EnvironmentSettings.newInstance().inStreamingMode().build());
+          Configuration configuration = tEnv.getConfig().getConfiguration();
+          // set low-level key-value options
+          configuration.setString(TABLE_DYNAMIC_TABLE_OPTIONS_ENABLED.key(), "true");
+        }
+      }
+    }
+    return tEnv;
+  }
+
+  protected StreamExecutionEnvironment getEnv() {
+    if (env == null) {
+      synchronized (this) {
+        if (env == null) {
+          StateBackend backend =
+              new FsStateBackend(
+                  "file:///" + System.getProperty("java.io.tmpdir") + "/flink/backend");
+          env =
+              StreamExecutionEnvironment.getExecutionEnvironment(
+                  MiniClusterResource.DISABLE_CLASSLOADER_CHECK_CONFIG);
+          env.setParallelism(defaultParallelism());
+          env.getCheckpointConfig().setCheckpointingMode(CheckpointingMode.EXACTLY_ONCE);
+          env.getCheckpointConfig().setCheckpointInterval(300);
+          env.getCheckpointConfig()
+              .enableExternalizedCheckpoints(
+                  CheckpointConfig.ExternalizedCheckpointCleanup.RETAIN_ON_CANCELLATION);
+          env.setStateBackend(backend);
+          env.setRestartStrategy(RestartStrategies.noRestart());
+        }
+      }
+    }
+    return env;
+  }
+
+  protected int defaultParallelism() {
+    return 1;
+  }
+}

--- a/mixed/flink/v1.15/flink/pom.xml
+++ b/mixed/flink/v1.15/flink/pom.xml
@@ -65,6 +65,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-flink-1.15</artifactId>
+            <version>${paimon.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/mixed/flink/v1.16/flink/pom.xml
+++ b/mixed/flink/v1.16/flink/pom.xml
@@ -65,6 +65,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-flink-1.16</artifactId>
+            <version>${paimon.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/mixed/flink/v1.17/flink/pom.xml
+++ b/mixed/flink/v1.17/flink/pom.xml
@@ -65,6 +65,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-flink-1.17</artifactId>
+            <version>${paimon.version}</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.netease.com/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close https://github.com/NetEase/amoro/issues/2345.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- support UnifiedCatalog to contain Paimon format table in Flink Engine
- add FlinkAmoroCatalogITCase for Flink UnifiedCatalog based on AmoroCatalogTestBase

## How was this patch tested?

- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
no
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
