### PR TITLE
[Hotfix] Fix quickdemo docker image build error in GitHub action

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -213,7 +213,7 @@ jobs:
       - name: Set Amoro Tag
         id: tag
         run: |
-          AMORO_TAG=${{ steps.meta.outputs.tags }} && echo "AMORO_TAG=${AMORO_TAG#*:}" >> $GITHUB_OUTPUT
+          AMORO_TAG=$(echo "${{ steps.meta.outputs.tags }}" | head -n 1) && echo "AMORO_TAG=${AMORO_TAG#*:}" >> $GITHUB_OUTPUT
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.netease.com/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

The `quickdemo` docker image cannot be built successfully by Github action when releasing a new version, related error can be found here: https://github.com/NetEase/amoro/actions/runs/7984579979/job/21802352068.

We should fix it.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- To fix parsing errors, retrieve version information from the first line of the tag output.

## How was this patch tested?

After the modification, the image was successfully built in the 0.6.1 version release：
https://github.com/NetEase/amoro/actions/runs/7984948851

## Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable)
