### PR TITLE
[AMORO-2560]Filformat ORC support roll new file for mixed_format

### DIFF
--- a/core/src/main/java/com/netease/arctic/io/writer/BaseTaskWriter.java
+++ b/core/src/main/java/com/netease/arctic/io/writer/BaseTaskWriter.java
@@ -205,8 +205,7 @@ public abstract class BaseTaskWriter<T> implements TaskWriter<T> {
     }
 
     protected boolean shouldRollToNewFile(TaskDataWriter<T> dataWriter) {
-      // TODO: ORC file now not support target file size before closed
-      return !format.equals(FileFormat.ORC) && dataWriter.length() >= targetFileSize;
+      return dataWriter.length() >= targetFileSize;
     }
 
     protected TaskDataWriter<T> newWriter(TaskWriterKey writerKey) {

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
         <zookeeper.version>3.8.3</zookeeper.version>
         <fastjson.version>1.2.83</fastjson.version>
         <parquet-avro.version>1.13.1</parquet-avro.version>
-        <orc-core.version>1.7.2</orc-core.version>
+        <orc-core.version>1.8.3</orc-core.version>
         <awssdk.version>2.20.5</awssdk.version>
         <terminal.spark.version>3.3.2</terminal.spark.version>
         <terminal.spark.major.version>3.3</terminal.spark.major.version>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.netease.com/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close https://github.com/NetEase/amoro/issues/2560.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->


-ORC fileformat support roll new file with self-optimizing.target-size for mixed_format
-Change orc-core.version to 1.8.3 
because org.apache.iceberg.orc.OrcFileAppender#length would call org.apache.orc.Writer#estimateMemory, but it did not exsits in orc-core 1.7.2, which would cause java.lang.NoSuchMethodError: org.apache.orc.Writer.estimateMemory as below
![image](https://github.com/NetEase/amoro/assets/105206850/86f443a5-d96d-4014-a35b-ce714b391d28)

 
## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

![image](https://github.com/NetEase/amoro/assets/105206850/6409642a-c4f3-4150-b53d-53e542ddf433)


## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
