### PR TITLE
[AMORO-2571] Cannot find data files under partitions with null partition values

### DIFF
--- a/core/src/main/java/org/apache/iceberg/IcebergFindFiles.java
+++ b/core/src/main/java/org/apache/iceberg/IcebergFindFiles.java
@@ -42,6 +42,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
@@ -182,9 +183,12 @@ public class IcebergFindFiles {
       Expression partFilter = Expressions.alwaysTrue();
       for (int i = 0; i < spec.fields().size(); i += 1) {
         PartitionField field = spec.fields().get(i);
-        partFilter =
-            Expressions.and(
-                partFilter, Expressions.equal(field.name(), partitionData.get(i, Object.class)));
+        Object partitionValue = partitionData.get(i, Object.class);
+        if (Objects.isNull(partitionValue)) {
+          partFilter = Expressions.and(partFilter, Expressions.isNull(field.name()));
+        } else {
+          partFilter = Expressions.and(partFilter, Expressions.equal(field.name(), partitionValue));
+        }
       }
       partitionSetFilter = Expressions.or(partitionSetFilter, partFilter);
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.netease.com/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close #2571.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

-

## How was this patch tested?

- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not documented)
