### PR TITLE
[Hotfix][Infra] Fix github labeler action configuration for ams-server module

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -48,7 +48,7 @@
 
 "module:ams-server":
   - "ams/api/**/*"
-  - "ams/ams-server/**/*"
+  - "ams/server/**/*"
 
 "module:ams-dashboard":
   - "ams/dashboard/**/*"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.netease.com/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

The labeler action cannot label the `ams-server` properly because of some error configuration, we need to fix it.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- Fix the labeler configuration for `ams-server` module

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
