### PR TITLE
[AMORO-2576] Fix the configuring JVM options error in `entrypoint.sh`

### DIFF
--- a/docker/amoro/entrypoint.sh
+++ b/docker/amoro/entrypoint.sh
@@ -34,9 +34,9 @@ configure_jvm_options() {
     declare -l lowerKey=$key
     if grep "$lowerKey" "$JVM_PROPERTIES_FILE" >/dev/null
     then
-       sed -i "s/$lowerKey=.*$/$lowerKey=\"$value\"/g" "$JVM_PROPERTIES_FILE"
+       sed -i "s/$lowerKey=.*$/$lowerKey=$value/g" "$JVM_PROPERTIES_FILE"
     else
-       sed -i '$a/'"$lowerKey=\"$value\""  "$JVM_PROPERTIES_FILE"
+       sed -i '$a'"$lowerKey=$value"  "$JVM_PROPERTIES_FILE"
     fi
   done
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.netease.com/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close #2576.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- When writing to the JVM configuration file, remove the quotation marks from the value section.
- When adding a new configuration, remove excess slash(/).

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not documented)
