### PR TITLE
[AMORO-2601] Paimon tableformat for 'Commit Time' in File pages and 'Start Time' in Optimizing pages

### DIFF
--- a/ams/server/src/main/java/com/netease/arctic/server/dashboard/PaimonTableDescriptor.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/dashboard/PaimonTableDescriptor.java
@@ -345,7 +345,7 @@ public class PaimonTableDescriptor implements FormatTableDescriptor {
           new PartitionFileBaseInfo(
               snapshotId == null ? null : snapshotId.toString(),
               INSERT_FILE,
-              manifestEntry.file().creationTime().getMillisecond(),
+              manifestEntry.file().creationTimeEpochMillis(),
               partitionSt,
               0,
               fullFilePath(store, manifestEntry),
@@ -409,11 +409,11 @@ public class PaimonTableDescriptor implements FormatTableDescriptor {
                           minCreateTime =
                               Math.min(
                                   minCreateTime,
-                                  compactManifestEntry.file().creationTime().getMillisecond());
+                                  compactManifestEntry.file().creationTimeEpochMillis());
                           maxCreateTime =
                               Math.max(
                                   maxCreateTime,
-                                  compactManifestEntry.file().creationTime().getMillisecond());
+                                  compactManifestEntry.file().creationTimeEpochMillis());
                           outputBuilder.addFile(compactManifestEntry.file().fileSize());
                         }
                       }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.netease.com/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close  https://github.com/NetEase/amoro/issues/2601.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->


-fix:  File pages for paimon tableformat, 'Commit Time' for file has wrong zone
fix: Optimizing pages for paimon tableformat, 'Start Time' for file has wrong zone and wrong value for Duration

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate
File 'Commit Time' on ams-server
![image](https://github.com/NetEase/amoro/assets/105206850/24fa9692-aade-4915-95eb-d2c1b818a340)
FIle createTime in HDFS filesystem
![image](https://github.com/NetEase/amoro/assets/105206850/cd764a30-9917-4898-a2aa-0c89edb7607b)
Optimizing pages for 'Start Time'  and 'Duration'
![image](https://github.com/NetEase/amoro/assets/105206850/4106c2c8-e0f2-4052-a30e-74fb8a3a02d9)

- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
