### PR TITLE
[AMORO-2607]'Last Commit Time' for Paimon partition table in File pages has wrong zone

### DIFF
--- a/ams/server/src/main/java/com/netease/arctic/server/dashboard/PaimonTableDescriptor.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/dashboard/PaimonTableDescriptor.java
@@ -238,7 +238,7 @@ public class PaimonTableDescriptor implements FormatTableDescriptor {
             new PartitionFileBaseInfo(
                 null,
                 DataFileType.BASE_FILE,
-                entry.file().creationTime().getMillisecond(),
+                entry.file().creationTimeEpochMillis(),
                 partitionString(entry.partition(), entry.bucket(), fileStorePathFactory),
                 fullFilePath(store, entry),
                 entry.file().fileSize(),
@@ -279,7 +279,7 @@ public class PaimonTableDescriptor implements FormatTableDescriptor {
         for (DataFileMeta dataFileMeta : groupByBucketEntry.getValue()) {
           fileCount++;
           fileSize += dataFileMeta.fileSize();
-          lastCommitTime = Math.max(lastCommitTime, dataFileMeta.creationTime().getMillisecond());
+          lastCommitTime = Math.max(lastCommitTime, dataFileMeta.creationTimeEpochMillis());
         }
         partitionBaseInfoList.add(
             new PartitionBaseInfo(partitionSt, 0, fileCount, fileSize, lastCommitTime));


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.netease.com/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close https://github.com/NetEase/amoro/issues/2607.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- Fix: 'Last Commit Time' for Paimon partition table in File pages has wrong zone

## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate
for partition updatae_day=2024-03-08 'Last Commit Time' is '2024-03-08 18:24:03' on dashboard as below
![image](https://github.com/NetEase/amoro/assets/105206850/eb6bc718-de62-4e7d-91ff-fc536c3da98c)


update time is  also '2024-03-08 18:24' in hdfs filesystem

![image](https://github.com/NetEase/amoro/assets/105206850/434f7f5d-d089-49e5-ae56-8f105655587d)


- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
