### PR TITLE
[AMORO-2640]Adjust the test case for different catalog factory under mixed/flink module

### DIFF
--- a/mixed-format/flink/flink-common/src/test/java/com/netease/arctic/flink/catalog/TestMixedCatalog.java
+++ b/mixed-format/flink/flink-common/src/test/java/com/netease/arctic/flink/catalog/TestMixedCatalog.java
@@ -18,7 +18,13 @@
 
 package com.netease.arctic.flink.catalog;
 
-import static com.netease.arctic.MockArcticMetastoreServer.TEST_CATALOG_NAME;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import static com.netease.arctic.flink.FlinkSchemaUtil.COMPUTED_COLUMNS;
 import static com.netease.arctic.flink.FlinkSchemaUtil.FLINK_PREFIX;
 import static com.netease.arctic.flink.FlinkSchemaUtil.WATERMARK;
@@ -29,12 +35,18 @@ import static org.apache.flink.table.descriptors.DescriptorProperties.NAME;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_ROWTIME;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_STRATEGY_DATA_TYPE;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_STRATEGY_EXPR;
-
 import com.netease.arctic.TableFormat;
 import com.netease.arctic.TableTestHelper;
 import com.netease.arctic.catalog.BasicCatalogTestHelper;
 import com.netease.arctic.catalog.CatalogTestBase;
 import com.netease.arctic.flink.catalog.factories.CatalogFactoryOptions;
+import com.netease.arctic.formats.IcebergHadoopCatalogTestHelper;
+import com.netease.arctic.formats.MixedIcebergHadoopCatalogTestHelper;
+import com.netease.arctic.formats.PaimonHadoopCatalogTestHelper;
+import com.netease.arctic.hive.catalog.HiveCatalogTestHelper;
+import com.netease.arctic.hive.formats.IcebergHiveCatalogTestHelper;
+import com.netease.arctic.hive.formats.MixedIcebergHiveCatalogTestHelper;
+import com.netease.arctic.hive.formats.PaimonHiveCatalogTestHelper;
 import com.netease.arctic.table.ArcticTable;
 import com.netease.arctic.table.TableIdentifier;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
@@ -59,22 +71,37 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ExecutionException;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+/**
+ * Test cases for mixed catalog factories, including:
+ * CatalogFactoryOptions.MIXED_ICEBERG_IDENTIFIER,
+ * CatalogFactoryOptions.MIXED_HIVE_IDENTIFIER,
+ * CatalogFactoryOptions.LEGACY_MIXED_IDENTIFIER
+ */
+@RunWith(value = Parameterized.class)
+public class TestMixedCatalog extends CatalogTestBase {
+  private String catalogName;
+  private String catalogFactoryType;
+  private static final Logger LOG = LoggerFactory.getLogger(TestMixedCatalog.class);
 
-public class TestLegacyMixedCatalog extends CatalogTestBase {
-  private static final Logger LOG = LoggerFactory.getLogger(TestLegacyMixedCatalog.class);
-
-  public TestLegacyMixedCatalog() {
+  public TestMixedCatalog(String catalogFactoryType) {
     super(new BasicCatalogTestHelper(TableFormat.MIXED_ICEBERG));
+    this.catalogFactoryType = catalogFactoryType;
+    this.catalogName = catalogFactoryType +"_catalog";
+  }
+
+
+  @Parameterized.Parameters(name = "catalogFactoryType = {0}")
+  public static Object[] parameters() {
+    return new Object[] {
+        CatalogFactoryOptions.MIXED_ICEBERG_IDENTIFIER,
+        CatalogFactoryOptions.MIXED_HIVE_IDENTIFIER,
+        CatalogFactoryOptions.LEGACY_MIXED_IDENTIFIER
+    };
   }
 
   @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
@@ -82,51 +109,43 @@ public class TestLegacyMixedCatalog extends CatalogTestBase {
 
   private static final String DB = TableTestHelper.TEST_DB_NAME;
   private static final String TABLE = TableTestHelper.TEST_TABLE_NAME;
-  private static final String CATALOG = "arcticCatalog";
   private volatile StreamExecutionEnvironment env = null;
   private volatile StreamTableEnvironment tEnv = null;
 
   @Before
   public void before() throws Exception {
     props = Maps.newHashMap();
-    props.put("type", CatalogFactoryOptions.LEGACY_MIXED_IDENTIFIER);
+    props.put("type", catalogFactoryType);
     props.put(CatalogFactoryOptions.METASTORE_URL.key(), getCatalogUrl());
-    sql("CREATE CATALOG " + CATALOG + " WITH %s", toWithClause(props));
-    sql("USE CATALOG " + CATALOG);
-    sql("CREATE DATABASE " + CATALOG + "." + DB);
+    sql("CREATE CATALOG " + catalogName+ " WITH %s", toWithClause(props));
+    sql("USE CATALOG " + catalogName);
+    sql("CREATE DATABASE " + catalogName + "." + DB);
   }
 
   @After
   public void after() {
-    sql("DROP TABLE IF EXISTS " + CATALOG + "." + DB + "." + TABLE);
-    sql("DROP DATABASE IF EXISTS " + CATALOG + "." + DB);
+    sql("DROP TABLE IF EXISTS " + catalogName + "." + DB + "." + TABLE);
+    sql("DROP DATABASE IF EXISTS " + catalogName + "." + DB);
     Assert.assertTrue(CollectionUtil.isNullOrEmpty(getMixedFormatCatalog().listDatabases()));
     sql("USE CATALOG default_catalog");
-    sql("DROP CATALOG " + CATALOG);
+    sql("DROP CATALOG " + catalogName);
   }
 
   @Test
-  public void testCreateIcebergHiveCatalog() {
-    sql(
-        "CREATE CATALOG mixed_iceberg_catalog WITH ('type'='mixed_iceberg', 'metastore.url'='%s')",
-        getCatalogUrl());
-    sql(
-        "CREATE CATALOG mixed_hive_catalog WITH ('type'='mixed_hive', 'metastore.url'='%s')",
-        getCatalogUrl());
-
+  public void testMixedCatalog() {
     String[] catalogs = getTableEnv().listCatalogs();
     Assert.assertArrayEquals(
         Arrays.stream(catalogs).sorted().toArray(),
-        Stream.of("default_catalog", "arcticCatalog", "mixed_iceberg_catalog", "mixed_hive_catalog")
+        Stream.of("default_catalog", catalogName)
             .sorted()
             .toArray());
   }
 
   @Test
-  public void testDDL() throws IOException {
+  public void testDDL() {
     sql(
         "CREATE TABLE "
-            + CATALOG
+            + catalogName
             + "."
             + DB
             + "."
@@ -137,15 +156,13 @@ public class TestLegacyMixedCatalog extends CatalogTestBase {
             + " t TIMESTAMP,"
             + " PRIMARY KEY (id) NOT ENFORCED "
             + ") PARTITIONED BY(t) "
-            + " WITH ("
-            + " 'connector' = 'arctic'"
-            + ")");
-    sql("USE  arcticCatalog." + DB);
+    );
+    sql("USE  " + catalogName + "." + DB);
     sql("SHOW tables");
 
     Assert.assertTrue(
         getMixedFormatCatalog()
-            .loadTable(TableIdentifier.of(TEST_CATALOG_NAME, DB, TABLE))
+            .loadTable(TableIdentifier.of(catalogName, DB, TABLE))
             .isKeyedTable());
   }
 
@@ -157,7 +174,7 @@ public class TestLegacyMixedCatalog extends CatalogTestBase {
         () ->
             sql(
                 "CREATE TABLE "
-                    + CATALOG
+                    + catalogName
                     + "."
                     + DB
                     + "."
@@ -168,14 +185,12 @@ public class TestLegacyMixedCatalog extends CatalogTestBase {
                     + " proc as PROCTIME() ,"
                     + " name STRING"
                     + ") "
-                    + " WITH ("
-                    + " 'connector' = 'arctic'"
-                    + ")"));
+            ));
 
     // compute column must come after all the physical columns
     sql(
         "CREATE TABLE "
-            + CATALOG
+            + catalogName
             + "."
             + DB
             + "."
@@ -184,9 +199,7 @@ public class TestLegacyMixedCatalog extends CatalogTestBase {
             + " id INT,"
             + " proc as PROCTIME() "
             + ") "
-            + " WITH ("
-            + " 'connector' = 'arctic'"
-            + ")");
+    );
   }
 
   @Test
@@ -196,7 +209,7 @@ public class TestLegacyMixedCatalog extends CatalogTestBase {
     // datatype manually
     sql(
         "CREATE TABLE "
-            + CATALOG
+            + catalogName
             + "."
             + DB
             + "."
@@ -211,13 +224,11 @@ public class TestLegacyMixedCatalog extends CatalogTestBase {
             + " watermark FOR t3 AS t3 - INTERVAL '5' SECOND, "
             + " PRIMARY KEY (id) NOT ENFORCED "
             + ") PARTITIONED BY(t) "
-            + " WITH ("
-            + " 'connector' = 'arctic'"
-            + ")");
+    );
 
     Map<String, String> properties =
         getMixedFormatCatalog()
-            .loadTable(TableIdentifier.of(TEST_CATALOG_NAME, DB, TABLE))
+            .loadTable(TableIdentifier.of(catalogName, DB, TABLE))
             .properties();
 
     // index for compute columns
@@ -241,7 +252,7 @@ public class TestLegacyMixedCatalog extends CatalogTestBase {
     Assert.assertTrue(
         properties.containsKey(compoundKey(FLINK_PREFIX, WATERMARK, WATERMARK_STRATEGY_DATA_TYPE)));
 
-    List<Row> result = sql("DESC " + CATALOG + "." + DB + "." + TABLE + "");
+    List<Row> result = sql("DESC " + catalogName + "." + DB + "." + TABLE + "");
     Assert.assertEquals(6, result.size());
   }
 
@@ -250,7 +261,7 @@ public class TestLegacyMixedCatalog extends CatalogTestBase {
     // create arctic table with compute columns under arctic catalog
     sql(
         "CREATE TABLE "
-            + CATALOG
+            + catalogName
             + "."
             + DB
             + "."
@@ -262,9 +273,7 @@ public class TestLegacyMixedCatalog extends CatalogTestBase {
             + " proc as PROCTIME(), "
             + " PRIMARY KEY (id) NOT ENFORCED "
             + ") PARTITIONED BY(t) "
-            + " WITH ("
-            + " 'connector' = 'arctic'"
-            + ")");
+    );
 
     // insert values into arctic table
     insertValue();
@@ -273,7 +282,7 @@ public class TestLegacyMixedCatalog extends CatalogTestBase {
     List<Row> rows =
         sql(
             "SELECT * FROM "
-                + CATALOG
+                + catalogName
                 + "."
                 + DB
                 + "."
@@ -289,7 +298,7 @@ public class TestLegacyMixedCatalog extends CatalogTestBase {
     // create arctic table with compute columns under arctic catalog
     sql(
         "CREATE TABLE "
-            + CATALOG
+            + catalogName
             + "."
             + DB
             + "."
@@ -301,12 +310,10 @@ public class TestLegacyMixedCatalog extends CatalogTestBase {
             + " compute_id as id+5 ,"
             + " PRIMARY KEY (id) NOT ENFORCED "
             + ") PARTITIONED BY(t) "
-            + " WITH ("
-            + " 'connector' = 'arctic'"
-            + ")");
+    );
 
     ArcticTable amoroTable =
-        getMixedFormatCatalog().loadTable(TableIdentifier.of(TEST_CATALOG_NAME, DB, TABLE));
+        getMixedFormatCatalog().loadTable(TableIdentifier.of(catalogName, DB, TABLE));
     String beforeExpr =
         amoroTable.properties().get(compoundKey(FLINK_PREFIX, COMPUTED_COLUMNS, 2, EXPR));
     // change property "flink.computed-column.2.expr" from "`id` +5" to "`newId` +5"
@@ -322,15 +329,15 @@ public class TestLegacyMixedCatalog extends CatalogTestBase {
 
     // property for expr do not match any columns in amoro, will throw exception.
     Assert.assertThrows(
-        java.lang.IllegalStateException.class,
-        () -> sql("DESC " + CATALOG + "." + DB + "." + TABLE + ""));
+        IllegalStateException.class,
+        () -> sql("DESC " + catalogName + "." + DB + "." + TABLE + ""));
     amoroTable
         .updateProperties()
         .set(compoundKey(FLINK_PREFIX, COMPUTED_COLUMNS, 2, EXPR), beforeExpr)
         .commit();
 
     // can get table normally
-    sql("DESC " + CATALOG + "." + DB + "." + TABLE + "");
+    sql("DESC " + catalogName + "." + DB + "." + TABLE + "");
   }
 
   @Test
@@ -352,7 +359,7 @@ public class TestLegacyMixedCatalog extends CatalogTestBase {
             + ")");
     sql(
         "CREATE TABLE "
-            + CATALOG
+            + catalogName
             + "."
             + DB
             + "."
@@ -363,13 +370,11 @@ public class TestLegacyMixedCatalog extends CatalogTestBase {
             + " t TIMESTAMP,"
             + " PRIMARY KEY (id) NOT ENFORCED "
             + ") PARTITIONED BY(t) "
-            + " WITH ("
-            + " 'connector' = 'arctic'"
-            + ")");
+    );
 
     sql(
         "INSERT INTO "
-            + CATALOG
+            + catalogName
             + "."
             + DB
             + "."
@@ -379,7 +384,7 @@ public class TestLegacyMixedCatalog extends CatalogTestBase {
     List<Row> rows =
         sql(
             "SELECT * FROM "
-                + CATALOG
+                + catalogName
                 + "."
                 + DB
                 + "."
@@ -392,59 +397,62 @@ public class TestLegacyMixedCatalog extends CatalogTestBase {
     sql("DROP TABLE default_catalog.default_database." + TABLE);
   }
 
+
   @Test
   public void testDefaultCatalogDDLWithVirtualColumn() {
+    //this test only for LEGACY_MIXED_IDENTIFIER
+    if(catalogFactoryType.equals(CatalogFactoryOptions.LEGACY_MIXED_IDENTIFIER)) {
+      // create arctic table with only physical columns
+      sql(
+          "CREATE TABLE "
+              + catalogName
+              + "."
+              + DB
+              + "."
+              + TABLE
+              + " ("
+              + " id INT,"
+              + " t TIMESTAMP(6),"
+              + " PRIMARY KEY (id) NOT ENFORCED "
+              + ") PARTITIONED BY(t) "
+              + " WITH ("
+              + " 'connector' = 'arctic'"
+              + ")");
 
-    // create arctic table with only physical columns
-    sql(
-        "CREATE TABLE "
-            + CATALOG
-            + "."
-            + DB
-            + "."
-            + TABLE
-            + " ("
-            + " id INT,"
-            + " t TIMESTAMP(6),"
-            + " PRIMARY KEY (id) NOT ENFORCED "
-            + ") PARTITIONED BY(t) "
-            + " WITH ("
-            + " 'connector' = 'arctic'"
-            + ")");
+      // insert values into arctic table
+      insertValue();
 
-    // insert values into arctic table
-    insertValue();
+      // create Table with compute columns under default catalog
+      props = Maps.newHashMap();
+      props.put("connector", CatalogFactoryOptions.LEGACY_MIXED_IDENTIFIER);
+      props.put(CatalogFactoryOptions.METASTORE_URL.key(), getCatalogUrl());
+      props.put(CatalogFactoryOptions.LEGACY_MIXED_IDENTIFIER + ".catalog", catalogName);
+      props.put(CatalogFactoryOptions.LEGACY_MIXED_IDENTIFIER + ".database", DB);
+      props.put(CatalogFactoryOptions.LEGACY_MIXED_IDENTIFIER + ".table", TABLE);
 
-    // create Table with compute columns under default catalog
-    props = Maps.newHashMap();
-    props.put("connector", CatalogFactoryOptions.LEGACY_MIXED_IDENTIFIER);
-    props.put(CatalogFactoryOptions.METASTORE_URL.key(), getCatalogUrl());
-    props.put(CatalogFactoryOptions.LEGACY_MIXED_IDENTIFIER + ".catalog", CATALOG);
-    props.put(CatalogFactoryOptions.LEGACY_MIXED_IDENTIFIER + ".database", DB);
-    props.put(CatalogFactoryOptions.LEGACY_MIXED_IDENTIFIER + ".table", TABLE);
+      sql(
+          "CREATE TABLE default_catalog.default_database."
+              + TABLE
+              + " ("
+              + " id INT,"
+              + " t TIMESTAMP(6),"
+              + " compute_id as id+5 ,"
+              + " proc as PROCTIME(), "
+              + " PRIMARY KEY (id) NOT ENFORCED "
+              + ") PARTITIONED BY(t) "
+              + "WITH %s",
+          toWithClause(props));
 
-    sql(
-        "CREATE TABLE default_catalog.default_database."
-            + TABLE
-            + " ("
-            + " id INT,"
-            + " t TIMESTAMP(6),"
-            + " compute_id as id+5 ,"
-            + " proc as PROCTIME(), "
-            + " PRIMARY KEY (id) NOT ENFORCED "
-            + ") PARTITIONED BY(t) "
-            + "WITH %s",
-        toWithClause(props));
-
-    // select from arctic table with compute columns under default catalog
-    List<Row> rows =
-        sql(
-            "SELECT * FROM default_catalog.default_database."
-                + TABLE
-                + " /*+ OPTIONS("
-                + "'streaming'='false'"
-                + ") */");
-    checkRows(rows);
+      // select from arctic table with compute columns under default catalog
+      List<Row> rows =
+          sql(
+              "SELECT * FROM default_catalog.default_database."
+                  + TABLE
+                  + " /*+ OPTIONS("
+                  + "'streaming'='false'"
+                  + ") */");
+      checkRows(rows);
+    }
   }
 
   private void checkRows(List<Row> rows) {
@@ -562,7 +570,7 @@ public class TestLegacyMixedCatalog extends CatalogTestBase {
 
     sql(
         "INSERT INTO "
-            + CATALOG
+            + catalogName
             + "."
             + DB
             + "."
@@ -576,7 +584,9 @@ public class TestLegacyMixedCatalog extends CatalogTestBase {
   @Test
   public void testAlterUnKeyTable() throws Exception {
     sql(
-        "CREATE TABLE arcticCatalog."
+        "CREATE TABLE "
+            + catalogName
+            + "."
             + DB
             + "."
             + TABLE
@@ -586,12 +596,13 @@ public class TestLegacyMixedCatalog extends CatalogTestBase {
             + " t TIMESTAMP"
             + ") PARTITIONED BY(t) "
             + " WITH ("
-            + " 'connector' = 'arctic',"
             + " 'self-optimizing.enabled' = 'false'"
             + ")");
 
     sql(
-        "ALTER TABLE arcticCatalog."
+        "ALTER TABLE "
+            + catalogName
+            + "."
             + DB
             + "."
             + TABLE
@@ -599,7 +610,7 @@ public class TestLegacyMixedCatalog extends CatalogTestBase {
             + "SET ( 'write.metadata.delete-after-commit.enabled' = 'false')");
     Map<String, String> unKeyTableProperties =
         getMixedFormatCatalog()
-            .loadTable(TableIdentifier.of(TEST_CATALOG_NAME, DB, TABLE))
+            .loadTable(TableIdentifier.of(catalogName, DB, TABLE))
             .properties();
     Assert.assertEquals(
         unKeyTableProperties.get("write.metadata.delete-after-commit.enabled"), "false");
@@ -608,7 +619,9 @@ public class TestLegacyMixedCatalog extends CatalogTestBase {
   @Test
   public void testAlterKeyTable() throws Exception {
     sql(
-        "CREATE TABLE arcticCatalog."
+        "CREATE TABLE "
+            + catalogName
+            + "."
             + DB
             + "."
             + TABLE
@@ -618,18 +631,20 @@ public class TestLegacyMixedCatalog extends CatalogTestBase {
             + " t TIMESTAMP,"
             + " PRIMARY KEY (id) NOT ENFORCED "
             + ") PARTITIONED BY(t) "
-            + " WITH ("
-            + " 'connector' = 'arctic'"
-            + ")");
+    );
     sql(
-        "ALTER TABLE arcticCatalog."
+        "ALTER TABLE "
+            + catalogName
+            + "."
             + DB
             + "."
             + TABLE
             + " "
             + "SET ( 'self-optimizing.group' = 'flink')");
     sql(
-        "ALTER TABLE arcticCatalog."
+        "ALTER TABLE "
+            + catalogName
+            + "."
             + DB
             + "."
             + TABLE
@@ -637,7 +652,9 @@ public class TestLegacyMixedCatalog extends CatalogTestBase {
             + "SET ( 'self-optimizing.enabled' = 'true')");
 
     sql(
-        "ALTER TABLE arcticCatalog."
+        "ALTER TABLE "
+            + catalogName
+            + "."
             + DB
             + "."
             + TABLE
@@ -646,7 +663,7 @@ public class TestLegacyMixedCatalog extends CatalogTestBase {
 
     Map<String, String> keyTableProperties =
         getMixedFormatCatalog()
-            .loadTable(TableIdentifier.of(TEST_CATALOG_NAME, DB, TABLE))
+            .loadTable(TableIdentifier.of(catalogName, DB, TABLE))
             .properties();
     Assert.assertEquals(keyTableProperties.get("self-optimizing.enabled"), "true");
     Assert.assertEquals(keyTableProperties.get("self-optimizing.group"), "flink");


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.netease.com/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close https://github.com/NetEase/amoro/issues/2640.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- rename TestLegacyMixedCatalog to TestMixedCatalog

- TestMixedCatalog containes test cases for mixed catalog factories, including: MIXED_ICEBERG_IDENTIFIER, MIXED_HIVE_IDENTIFIER, LEGACY_MIXED_IDENTIFIER

- use Juit Parameterized to make unit test cases also work for MIXED_ICEBERG_IDENTIFIER and MIXED_HIVE_IDENTIFIER, not only LEGACY_MIXED_IDENTIFIER

## How was this patch tested?

- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
