### PR TITLE
[AMORO-2647] fix `getsnapshotdetail` error when iceberg partition evolution

### DIFF
--- a/ams/server/src/main/java/com/netease/arctic/server/dashboard/MixedAndIcebergTableDescriptor.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/dashboard/MixedAndIcebergTableDescriptor.java
@@ -325,7 +325,13 @@ public class MixedAndIcebergTableDescriptor extends PersistentBase
                         commitId,
                         DataFileType.ofContentId(f.content().id()),
                         snapshotTime,
-                        arcticTable.spec().partitionToPath(f.partition()),
+                        arcticTable.isKeyedTable()
+                            ? arcticTable.spec().partitionToPath(f.partition())
+                            : arcticTable
+                                .asUnkeyedTable()
+                                .specs()
+                                .get(f.specId())
+                                .partitionToPath(f.partition()),
                         f.path().toString(),
                         f.fileSizeInBytes(),
                         "add")));
@@ -338,7 +344,13 @@ public class MixedAndIcebergTableDescriptor extends PersistentBase
                         commitId,
                         DataFileType.ofContentId(f.content().id()),
                         snapshotTime,
-                        arcticTable.spec().partitionToPath(f.partition()),
+                        arcticTable.isKeyedTable()
+                            ? arcticTable.spec().partitionToPath(f.partition())
+                            : arcticTable
+                            .asUnkeyedTable()
+                            .specs()
+                            .get(f.specId())
+                            .partitionToPath(f.partition()),
                         f.path().toString(),
                         f.fileSizeInBytes(),
                         "remove")));
@@ -351,7 +363,13 @@ public class MixedAndIcebergTableDescriptor extends PersistentBase
                         commitId,
                         DataFileType.ofContentId(f.content().id()),
                         snapshotTime,
-                        arcticTable.spec().partitionToPath(f.partition()),
+                        arcticTable.isKeyedTable()
+                            ? arcticTable.spec().partitionToPath(f.partition())
+                            : arcticTable
+                            .asUnkeyedTable()
+                            .specs()
+                            .get(f.specId())
+                            .partitionToPath(f.partition()),
                         f.path().toString(),
                         f.fileSizeInBytes(),
                         "add")));
@@ -364,7 +382,13 @@ public class MixedAndIcebergTableDescriptor extends PersistentBase
                         commitId,
                         DataFileType.ofContentId(f.content().id()),
                         snapshotTime,
-                        arcticTable.spec().partitionToPath(f.partition()),
+                        arcticTable.isKeyedTable()
+                            ? arcticTable.spec().partitionToPath(f.partition())
+                            : arcticTable
+                            .asUnkeyedTable()
+                            .specs()
+                            .get(f.specId())
+                            .partitionToPath(f.partition()),
                         f.path().toString(),
                         f.fileSizeInBytes(),
                         "remove")));

--- a/ams/server/src/main/java/com/netease/arctic/server/dashboard/MixedAndIcebergTableDescriptor.java
+++ b/ams/server/src/main/java/com/netease/arctic/server/dashboard/MixedAndIcebergTableDescriptor.java
@@ -347,10 +347,10 @@ public class MixedAndIcebergTableDescriptor extends PersistentBase
                         arcticTable.isKeyedTable()
                             ? arcticTable.spec().partitionToPath(f.partition())
                             : arcticTable
-                            .asUnkeyedTable()
-                            .specs()
-                            .get(f.specId())
-                            .partitionToPath(f.partition()),
+                                .asUnkeyedTable()
+                                .specs()
+                                .get(f.specId())
+                                .partitionToPath(f.partition()),
                         f.path().toString(),
                         f.fileSizeInBytes(),
                         "remove")));
@@ -366,10 +366,10 @@ public class MixedAndIcebergTableDescriptor extends PersistentBase
                         arcticTable.isKeyedTable()
                             ? arcticTable.spec().partitionToPath(f.partition())
                             : arcticTable
-                            .asUnkeyedTable()
-                            .specs()
-                            .get(f.specId())
-                            .partitionToPath(f.partition()),
+                                .asUnkeyedTable()
+                                .specs()
+                                .get(f.specId())
+                                .partitionToPath(f.partition()),
                         f.path().toString(),
                         f.fileSizeInBytes(),
                         "add")));
@@ -385,10 +385,10 @@ public class MixedAndIcebergTableDescriptor extends PersistentBase
                         arcticTable.isKeyedTable()
                             ? arcticTable.spec().partitionToPath(f.partition())
                             : arcticTable
-                            .asUnkeyedTable()
-                            .specs()
-                            .get(f.specId())
-                            .partitionToPath(f.partition()),
+                                .asUnkeyedTable()
+                                .specs()
+                                .get(f.specId())
+                                .partitionToPath(f.partition()),
                         f.path().toString(),
                         f.fileSizeInBytes(),
                         "remove")));


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.netease.com/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close #2647.

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->

- To obtain the partition path of the native iceberg table, you need to bring the specID.



## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
