### PR TITLE
[AMORO-2672][Bug]: The spark-runtime shade configuration specifies incorrect dependencies for common and spark

### DIFF
--- a/mixed-format/spark/v3.2/spark-runtime/pom.xml
+++ b/mixed-format/spark/v3.2/spark-runtime/pom.xml
@@ -58,8 +58,8 @@
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                             <artifactSet>
                                 <includes>
-                                    <include>com.netease.amoro:amoro-mixed-spark-3-common</include>
-                                    <include>com.netease.amoro:amoro-mixed-spark-3.2</include>
+                                    <include>com.netease.amoro:amoro-mixed-format-spark-3-common</include>
+                                    <include>com.netease.amoro:amoro-mixed-format-spark-3.2</include>
                                     <include>com.netease.amoro:amoro-core</include>
                                     <include>com.netease.amoro:amoro-ams-api</include>
                                     <include>com.netease.amoro:amoro-mixed-format-hive</include>

--- a/mixed-format/spark/v3.3/spark-runtime/pom.xml
+++ b/mixed-format/spark/v3.3/spark-runtime/pom.xml
@@ -58,8 +58,8 @@
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                             <artifactSet>
                                 <includes>
-                                    <include>com.netease.amoro:amoro-mixed-spark-3-common</include>
-                                    <include>com.netease.amoro:amoro-mixed-spark-3.3</include>
+                                    <include>com.netease.amoro:amoro-mixed-format-spark-3-common</include>
+                                    <include>com.netease.amoro:amoro-mixed-format-spark-3.3</include>
                                     <include>com.netease.amoro:amoro-core</include>
                                     <include>com.netease.amoro:amoro-ams-api</include>
                                     <include>com.netease.amoro:amoro-mixed-format-hive</include>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://amoro.netease.com/how-to-contribute/
  2. If the PR is related to an issue in https://github.com/NetEase/amoro/issues, add '[AMORO-XXXX]' in your PR title, e.g., '[AMORO-XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][AMORO-XXXX] Your PR title ...'.
-->

## Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about its use case.
  2. If you fix a bug, you can clarify why it is a bug.
  3. Use Fix/Resolve/Close #{ISSUE_NUMBER} to link this PR to its related issue
-->

Close #2672 

## Brief change log
<!--
Clearly describe the changes made in modules, classes, methods, etc.
-->


## How was this patch tested?

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] Run test locally before making a pull request

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
